### PR TITLE
Persistent and perma weight, galbanic and macerinic

### DIFF
--- a/code/modules/reagents/withdrawal/_addiction.dm
+++ b/code/modules/reagents/withdrawal/_addiction.dm
@@ -105,7 +105,7 @@
 		if(3)
 			withdrawal_stage_3_process(affected_carbon, seconds_per_tick)
 
-	LAZYADDASSOC(affected_carbon.mind.active_addictions, type, 1 * seconds_per_tick) //Next cycle!
+	LAZYADDASSOC(affected_carbon.mind.active_addictions, type, current_addiction_cycle + (1 / seconds_per_tick)) //Next cycle! // GS13 EDIT - fix for the stage not advancing properly
 
 /// Called when addiction enters stage 1
 /datum/addiction/proc/withdrawal_enters_stage_1(mob/living/carbon/affected_carbon)

--- a/modular_gs/code/mechanics/fatness.dm
+++ b/modular_gs/code/mechanics/fatness.dm
@@ -181,14 +181,10 @@
 		if(max_weight)	//Check for max weight prefs
 			fatness = min(fatness, (max_weight - 1))	//Apply max weight prefs
 
-/mob/living/carbon/proc/adjust_perma(adjustment_amount, type_of_fattening = FATTENING_TYPE_ITEM)
-	/// we will fix this later
-	/*
-	return TRUE
-
-	if(!client)
+/mob/living/carbon/proc/adjust_perma(adjustment_amount, type_of_fattening = FATTENING_TYPE_ITEM, ignore_rate = FALSE)
+	if(isnull(client))
 		return FALSE
-	if(!client.prefs.weight_gain_permanent)
+	if(!client.prefs.read_preference(/datum/preference/toggle/weight_gain_permanent))
 		return FALSE
 
 	if(!adjustment_amount || !type_of_fattening)
@@ -200,16 +196,15 @@
 	var/amount_to_change = adjustment_amount
 
 	if(adjustment_amount > 0)
-		amount_to_change = amount_to_change * weight_gain_rate
+		amount_to_change = amount_to_change * (weight_gain_rate * !ignore_rate)
 	else
-		amount_to_change = amount_to_change * weight_loss_rate
+		amount_to_change = amount_to_change * (weight_loss_rate * !ignore_rate)
 
 	fatness_perma += amount_to_change
 	fatness_perma = max(fatness_perma, MINIMUM_FATNESS_LEVEL)
 
 	if(max_weight)
 		fatness_perma = min(fatness_perma, (max_weight - 1))
-	*/
 
 /mob/living/carbon/human/handle_breathing(times_fired)
 	. = ..()
@@ -279,12 +274,13 @@
 	adjust_fatness(fat_to_add, FATTENING_TYPE_WEAPON)
 	return fat_to_add
 
-/* Fix this later.
 /mob/living/carbon/proc/applyPermaFatnessDamage(amount)
-	if(!client?.prefs?.read_preference(/datum/preference/toggle/weight_gain_permanent)) // If we cant apply permafat, apply regular fat
+	if (isnull(client))
+		return
+	
+	if (!client.prefs.read_preference(/datum/preference/toggle/weight_gain_permanent)) // If we cant apply permafat, apply regular fat
 		return applyFatnessDamage(amount)
 
 	var/fat_to_add = ((amount * CONFIG_GET(number/damage_multiplier)) * PERMA_FAT_DAMAGE_TO_FATNESS)
 	adjust_perma(fat_to_add, FATTENING_TYPE_WEAPON)
 	return fat_to_add
-*/

--- a/modular_gs/code/mechanics/permanent_fat.dm
+++ b/modular_gs/code/mechanics/permanent_fat.dm
@@ -1,54 +1,69 @@
-/mob/living/carbon
-	var/savekey
-	var/ckeyslot
+/mob/living/carbon/human/become_uncliented()
+	if (isnull(canon_client))
+		return ..()
+	
+	if (isnull(canon_client.prefs))
+		return ..()
 
-/mob/living/carbon/proc/perma_fat_save()
-	var/key = savekey
-	if(!key || !client)
-		return FALSE
-	var/filename = "preferences.sav"
-	var/path = "data/player_saves/[key[1]]/[key]/[filename]"
+	// we know we have a client and they have prefs
+	if (canon_client.prefs.read_preference(/datum/preference/toggle/weight_gain_persistent))
+		canon_client.prefs.write_preference(GLOB.preference_entries[/datum/preference/numeric/starting_fatness], fatness_real)
 
-	var/savefile/S = new /savefile(path)
-	if(!path)
-		return FALSE
+	canon_client.prefs.write_preference(GLOB.preference_entries[/datum/preference/numeric/perma_fat_value], fatness_perma)
 
-	if(ckeyslot)
-		var/slot = ckeyslot
-		S.cd = "/character[slot]"
-
-		var/persi
-		S["weight_gain_persistent"] >> persi
-		if(persi)
-			WRITE_FILE(S["starting_weight"]			, fatness_real)
-			client.prefs.starting_weight = fatness_real
-			to_chat(src, span_notice("Your starting weight has been updated!"))
-		var/perma
-		S["weight_gain_permanent"] >> perma
-		if(S["weight_gain_permanent"])
-			WRITE_FILE(S["permanent_fat"]			, fatness_perma)
-			client.prefs.permanent_fat = fatness_perma
-			to_chat(src, span_notice("Your permanent fat has been updated!"))
-
-/mob/living/carbon/proc/queue_perma_save()
-	to_chat(src,"Your permanence options are being saved, please wait." )
-	addtimer(CALLBACK(src, PROC_REF(perma_fat_save), TRUE, silent), 3 SECONDS, TIMER_STOPPABLE)
-
-/datum/controller/subsystem/ticker/declare_completion()
 	. = ..()
-	for(var/mob/m in GLOB.player_list)
-		if(iscarbon(m))
-			var/mob/living/carbon/C = m
-			if(C)
-				C.queue_perma_save()
 
-/obj/machinery/cryopod/despawn_occupant()
-	var/mob/living/mob_occupant = occupant
-	if(iscarbon(mob_occupant))
-		var/mob/living/carbon/C = mob_occupant
-		if(C)
-			C.perma_fat_save(C)
-	. = ..()
+// /mob/living/carbon
+// 	var/savekey
+// 	var/ckeyslot
+
+// /mob/living/carbon/proc/perma_fat_save()
+// 	var/key = savekey
+// 	if(!key || !client)
+// 		return FALSE
+// 	var/filename = "preferences.sav"
+// 	var/path = "data/player_saves/[key[1]]/[key]/[filename]"
+
+// 	var/savefile/S = new /savefile(path)
+// 	if(!path)
+// 		return FALSE
+
+// 	if(ckeyslot)
+// 		var/slot = ckeyslot
+// 		S.cd = "/character[slot]"
+
+// 		var/persi
+// 		S["weight_gain_persistent"] >> persi
+// 		if(persi)
+// 			WRITE_FILE(S["starting_weight"]			, fatness_real)
+// 			client.prefs.starting_weight = fatness_real
+// 			to_chat(src, span_notice("Your starting weight has been updated!"))
+// 		var/perma
+// 		S["weight_gain_permanent"] >> perma
+// 		if(S["weight_gain_permanent"])
+// 			WRITE_FILE(S["permanent_fat"]			, fatness_perma)
+// 			client.prefs.permanent_fat = fatness_perma
+// 			to_chat(src, span_notice("Your permanent fat has been updated!"))
+
+// /mob/living/carbon/proc/queue_perma_save()
+// 	to_chat(src,"Your permanence options are being saved, please wait." )
+// 	addtimer(CALLBACK(src, PROC_REF(perma_fat_save), TRUE, silent), 3 SECONDS, TIMER_STOPPABLE)
+
+// /datum/controller/subsystem/ticker/declare_completion()
+// 	. = ..()
+// 	for(var/mob/m in GLOB.player_list)
+// 		if(iscarbon(m))
+// 			var/mob/living/carbon/C = m
+// 			if(C)
+// 				C.queue_perma_save()
+
+// /obj/machinery/cryopod/despawn_occupant()
+// 	var/mob/living/mob_occupant = occupant
+// 	if(iscarbon(mob_occupant))
+// 		var/mob/living/carbon/C = mob_occupant
+// 		if(C)
+// 			C.perma_fat_save(C)
+// 	. = ..()
 
 /*
 /datum/preferences/proc/perma_fat_save(character)

--- a/modular_gs/code/modules/client/preferences/fatness_preferences.dm
+++ b/modular_gs/code/modules/client/preferences/fatness_preferences.dm
@@ -9,7 +9,8 @@
 	return FATNESS_LEVEL_NONE
 
 /datum/preference/numeric/starting_fatness/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
-	target.fatness_real += value
+	// target.fatness_real += value
+	target.adjust_fatness(value, FATTENING_TYPE_ALMIGHTY, TRUE)
 
 
 /datum/preference/numeric/weight_gain_rate
@@ -51,3 +52,36 @@
 
 /datum/preference/numeric/max_weight/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
 	target.max_weight = value
+
+
+/datum/preference/toggle/weight_gain_persistent
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "weight_gain_persistent"
+	default_value = FALSE
+
+/datum/preference/toggle/weight_gain_persistent/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return
+
+/datum/preference/toggle/weight_gain_permanent
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "weight_gain_permanent"
+	default_value = FALSE
+
+/datum/preference/toggle/weight_gain_permanent/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return
+
+/datum/preference/numeric/perma_fat_value // this is a bit cancer but if it works it works
+	category = PREFERENCE_CATEGORY_MANUALLY_RENDERED
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "perma_fat_value"
+	minimum = FATNESS_LEVEL_NONE
+	maximum = INFINITY
+
+/datum/preference/numeric/perma_fat_value/create_default_value()
+	return FATNESS_LEVEL_NONE
+
+/datum/preference/numeric/perma_fat_value/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	// target.fatness_perma += value
+	target.adjust_perma(value, ignore_rate = TRUE)

--- a/modular_gs/code/modules/reagents/chemistry/reagents/fermi_fat.dm
+++ b/modular_gs/code/modules/reagents/chemistry/reagents/fermi_fat.dm
@@ -4,43 +4,31 @@
 	description = "A chemical compound derived from lipoifier. Massively increases adipose mass and parts of it become impossible to shed through normal means."
 	color = "#E70C0C"
 	taste_description = "hunger"
-	pH = 7
+	ph = 7
 	overdose_threshold = 50
-	metabolization_rate = REAGENTS_METABOLISM / 4
-	can_synth = FALSE //DO NOT MAKE THIS SNYTHESIZABLE, THESE CHEMS ARE SUPPOSED TO NOT BE USED COMMONLY
-
+	metabolization_rate = REAGENTS_METABOLISM / 2
 	overdose_threshold = 50
-	addiction_threshold = 100
-	addiction_stage1_end = 10
-	addiction_stage2_end = 30
-	addiction_stage3_end = 60
-	addiction_stage4_end = 100
+	addiction_types = list(/datum/addiction/fermi_fat = 4)
 
-	var/addiction_mults = 0
 
 //Reaction
 /datum/chemical_reaction/fermi_fat
-	name = "FermiFat"
-	id = /datum/reagent/fermi_fat
 	mix_message = "the reaction appears to swell!"
 	required_reagents = list(/datum/reagent/consumable/lipoifier = 0.1, /datum/reagent/medicine/pen_acid = 0.1, /datum/reagent/iron = 0.1)
 	results = list(/datum/reagent/fermi_fat = 0.2)
-	required_temp = 1
-	OptimalTempMin 		= 700		// Lower area of bell curve for determining heat based rate reactions
-	OptimalTempMax 		= 740		// Upper end for above
-	ExplodeTemp 		= 755 		// Temperature at which reaction explodes
-	OptimalpHMin 		= 2			// Lowest value of pH determining pH a 1 value for pH based rate reactions (Plateu phase)
-	OptimalpHMax 		= 3.5		// Higest value for above
-	ReactpHLim 			= 1 		// How far out pH wil react, giving impurity place (Exponential phase)
-	CatalystFact 		= 0 		// How much the catalyst affects the reaction (0 = no catalyst)
-	CurveSharpT 		= 4 		// How sharp the temperature exponential curve is (to the power of value)
-	CurveSharppH 		= 4 		// How sharp the pH exponential curve is (to the power of value)
-	ThermicConstant		= -10 		// Temperature change per 1u produced
-	HIonRelease 		= 0.02 		// pH change per 1u reaction (inverse for some reason)
-	RateUpLim 			= 2 		// Optimal/max rate possible if all conditions are perfect
-	FermiChem 			= TRUE		// If the chemical uses the Fermichem reaction mechanics
-	FermiExplode 		= FALSE		// If the chemical explodes in a special way
-	PurityMin 			= 0.1
+	required_temp 		= 700		// Lower area of bell curve for determining heat based rate reactions
+	optimal_temp 		= 740		// Upper end for above
+	overheat_temp 		= 755 		// Temperature at which reaction explodes
+	optimal_ph_min 		= 2			// Lowest value of pH determining pH a 1 value for pH based rate reactions (Plateu phase)
+	optimal_ph_max 		= 3.5		// Higest value for above
+	determin_ph_range 	= 1 		// How far out pH wil react, giving impurity place (Exponential phase)
+	temp_exponent_factor= 4 		// How sharp the temperature exponential curve is (to the power of value)
+	ph_exponent_factor	= 4 		// How sharp the pH exponential curve is (to the power of value)
+	thermic_constant	= -50 		// Temperature change per 1u produced
+	H_ion_release		= 0.02 		// pH change per 1u reaction (inverse for some reason)
+	rate_up_lim			= 2 		// Optimal/max rate possible if all conditions are perfect
+	purity_min 			= 0.1
+	reaction_flags 		= REACTION_CLEAR_RETAIN
 
 //When added
 /datum/reagent/fermi_fat/on_mob_add(mob/living/carbon/M)
@@ -68,78 +56,57 @@
 
 /datum/reagent/fermi_fat/overdose_start(mob/living/M)
 	to_chat(M, "<span class='userdanger'>You took too much [name]! Your body is growing out of control!</span>")
-	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "[type]_overdose", /datum/mood_event/overdose, name)
+	M.add_mood_event("[type]_overdose", /datum/mood_event/overdose, name)
 	return
 
-/datum/reagent/fermi_fat/addiction_act_stage1(mob/living/M)
-	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "[type]_overdose", /datum/mood_event/withdrawal_light, name)
+/datum/addiction/fermi_fat
+	name = "Galbanic"
+	addiction_gain_threshold = 80
+	addiction_loss_threshold = 0
+	var/addiction_mults = 0
+
+/datum/addiction/fermi_fat/withdrawal_stage_1_process(mob/living/carbon/affected_carbon, seconds_per_tick)
 	if(prob(30))
-		var/add_text = pick("You feel pretty hungry.", "You think of [name].", "Your look around for food.", "[name] wasn't so bad.")
-		to_chat(M, "<span class='notice'>[add_text]</span>")
-	if(iscarbon(M))
-		var/mob/living/carbon/C = M
-		C.adjust_fatness(1, FATTENING_TYPE_CHEM)
-		C.fullness = max(0, C.fullness-1)
-		C.nutrition = max(0, C.nutrition-1)
-		if(addiction_mults < 1)
-			C.nutri_mult += 0.5
-			C.weight_gain_rate += 0.25
-			addiction_mults = 1
-	return
+		var/add_text = pick("You feel pretty hungry.", "You think of [name].", "You look around for food.", "[name] wasn't so bad.")
+		to_chat(affected_carbon, "<span class='notice'>[add_text]</span>")
+	affected_carbon.adjust_fatness(1, FATTENING_TYPE_CHEM)
+	affected_carbon.fullness = max(0, affected_carbon.fullness-1)
+	affected_carbon.nutrition = max(0, affected_carbon.nutrition-1)
+	if(addiction_mults < 1)
+		// affected_carbon.nutri_mult += 0.5 commenting out since I can't be bothered for now
+		affected_carbon.weight_gain_rate += 0.25
+		addiction_mults = 1
 
-/datum/reagent/fermi_fat/addiction_act_stage2(mob/living/M)
-	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "[type]_overdose", /datum/mood_event/withdrawal_medium, name)
+/datum/addiction/fermi_fat/withdrawal_stage_2_process(mob/living/carbon/affected_carbon, seconds_per_tick)
 	if(prob(30))
-		var/add_text = pick("You are very hungry.", "You could go for some [name].", "Your mouth waters.", "Is there any [name] around?")
-		to_chat(M, "<span class='notice'>[add_text]</span>")
-	if(iscarbon(M))
-		var/mob/living/carbon/C = M
-		C.adjust_fatness(2, FATTENING_TYPE_CHEM)
-		C.fullness = max(0, C.fullness-2)
-		C.nutrition = max(0, C.nutrition-2)
-		if(addiction_mults < 2)
-			C.nutri_mult += 0.5
-			C.weight_gain_rate += 0.25
-			addiction_mults = 2
-	return
+		var/add_text = pick("You are very hungry.", "You need some [name]!", "Your stomach growls loudly!.", "Is there any [name] around?")
+		to_chat(affected_carbon, "<span class='notice'>[add_text]</span>")
+	affected_carbon.adjust_fatness(2, FATTENING_TYPE_CHEM)
+	affected_carbon.fullness = max(0, affected_carbon.fullness-2)
+	affected_carbon.nutrition = max(0, affected_carbon.nutrition-2)
+	if(addiction_mults < 2)
+		// affected_carbon.nutri_mult += 0.5
+		affected_carbon.weight_gain_rate += 0.25
+		addiction_mults = 2
 
-/datum/reagent/fermi_fat/addiction_act_stage3(mob/living/M)
-	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "[type]_overdose", /datum/mood_event/withdrawal_severe, name)
-	if(prob(30))
-		var/add_text = pick("You are starving!", "You need some [name]!", "Your stomach growls loudly!.", "You can't stop thinking about [name]")
-		to_chat(M, "<span class='danger'>[add_text]</span>")
-	if(iscarbon(M))
-		var/mob/living/carbon/C = M
-		C.adjust_fatness(3, FATTENING_TYPE_CHEM)
-		C.fullness = max(0, C.fullness-3)
-		C.nutrition = max(0, C.nutrition-3)
-		if(addiction_mults < 3)
-			C.nutri_mult += 0.5
-			C.weight_gain_rate += 0.25
-			addiction_mults = 3
-	return
-
-/datum/reagent/fermi_fat/addiction_act_stage4(mob/living/M)
-	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "[type]_overdose", /datum/mood_event/withdrawal_critical, name)
+/datum/addiction/fermi_fat/withdrawal_stage_3_process(mob/living/carbon/affected_carbon, seconds_per_tick)
 	if(prob(30))
 		var/add_text = pick("You are ravenous!!", "You need [name] NOW!!", "You'd eat ANYTHING!!", "Where is the [name]?!", "Hungry, hungry, so HUNGRY!!", "More, you need more!!")
-		to_chat(M, "<span class='boldannounce'>[add_text]</span>")
-	if(iscarbon(M))
-		var/mob/living/carbon/C = M
-		C.adjust_fatness(4, FATTENING_TYPE_CHEM)
-		C.fullness = max(0, C.fullness-4)
-		C.nutrition = max(0, C.nutrition-4)
-		if(addiction_mults < 4)
-			C.nutri_mult += 0.5
-			C.weight_gain_rate += 0.25
-			addiction_mults = 4
-	return
+		to_chat(affected_carbon, "<span class='boldannounce'>[add_text]</span>")
+	affected_carbon.adjust_fatness(4, FATTENING_TYPE_CHEM)
+	affected_carbon.fullness = max(0, affected_carbon.fullness-4)
+	affected_carbon.nutrition = max(0, affected_carbon.nutrition-4)
+	if(addiction_mults < 4)
+		// affected_carbon.nutri_mult += 0.5
+		affected_carbon.weight_gain_rate += 0.25
+		addiction_mults = 4
 
-/datum/reagent/fermi_fat/proc/addiction_remove(mob/living/carbon/C)
+/datum/addiction/fermi_fat/end_withdrawal(mob/living/carbon/C)
+	. = ..()
 	if(addiction_mults > 0)
-		C.nutri_mult = max(1, 0.5 * addiction_mults)
+		// C.nutri_mult = max(1, 0.5 * addiction_mults)
 		C.weight_gain_rate = max(0,11, 0.25 * addiction_mults)
-	return
+
 
 //Reagent
 /datum/reagent/fermi_slim
@@ -147,35 +114,28 @@
 	description = "A solution with unparalleled obesity-solving properties. One of the few things known to be capable of removing galbanic fat."
 	color = "#3b0ce7"
 	taste_description = "thinness"
-	pH = 7
-	metabolization_rate = REAGENTS_METABOLISM / 4
-	can_synth = FALSE
-
+	ph = 7
+	metabolization_rate = REAGENTS_METABOLISM / 2
 	overdose_threshold = 50
 
 //Reaction
 /datum/chemical_reaction/fermi_slim
-	name = "FermiSlim"
-	id = /datum/reagent/fermi_slim
 	mix_message = "the reaction seems to become thinner!"
 	required_reagents = list(/datum/reagent/toxin/lipolicide = 0.1, /datum/reagent/ammonia = 0.1, /datum/reagent/oxygen = 0.1)
 	results = list(/datum/reagent/fermi_slim = 0.2)
-	required_temp = 1
-	OptimalTempMin 		= 600		// Lower area of bell curve for determining heat based rate reactions
-	OptimalTempMax 		= 650		// Upper end for above
-	ExplodeTemp 		= 700 		// Temperature at which reaction explodes
-	OptimalpHMin 		= 10		// Lowest value of pH determining pH a 1 value for pH based rate reactions (Plateu phase)
-	OptimalpHMax 		= 11.5		// Higest value for above
-	ReactpHLim 			= 1 		// How far out pH wil react, giving impurity place (Exponential phase)
-	CatalystFact 		= 0 		// How much the catalyst affects the reaction (0 = no catalyst)
-	CurveSharpT 		= 4 		// How sharp the temperature exponential curve is (to the power of value)
-	CurveSharppH 		= 4 		// How sharp the pH exponential curve is (to the power of value)
-	ThermicConstant		= -10 		// Temperature change per 1u produced
-	HIonRelease 		= -0.02		// pH change per 1u reaction (inverse for some reason)
-	RateUpLim 			= 2 		// Optimal/max rate possible if all conditions are perfect
-	FermiChem 			= TRUE		// If the chemical uses the Fermichem reaction mechanics
-	FermiExplode 		= FALSE		// If the chemical explodes in a special way
-	PurityMin 			= 0.1
+	required_temp 		= 600		// Lower area of bell curve for determining heat based rate reactions
+	optimal_temp 		= 650		// Upper end for above
+	overheat_temp 		= 700 		// Temperature at which reaction explodes
+	optimal_ph_min 		= 10		// Lowest value of pH determining pH a 1 value for pH based rate reactions (Plateu phase)
+	optimal_ph_max 		= 11.5		// Higest value for above
+	determin_ph_range 	= 1 		// How far out pH wil react, giving impurity place (Exponential phase)
+	temp_exponent_factor= 4 		// How sharp the temperature exponential curve is (to the power of value)
+	ph_exponent_factor	= 4 		// How sharp the pH exponential curve is (to the power of value)
+	thermic_constant	= -50 		// Temperature change per 1u produced
+	H_ion_release		= -0.02		// pH change per 1u reaction (inverse for some reason)
+	rate_up_lim 		= 2 		// Optimal/max rate possible if all conditions are perfect
+	purity_min 			= 0.1
+	reaction_flags 		= REACTION_CLEAR_RETAIN
 
 //Effects
 /datum/reagent/fermi_slim/on_mob_life(mob/living/carbon/M)

--- a/modular_gs/code/obj/items/minor_items.dm
+++ b/modular_gs/code/obj/items/minor_items.dm
@@ -14,12 +14,16 @@
 	icon = 'modular_gs/icons/obj/fatoray.dmi'
 	icon_state = "fatoray_scrap2"
 	desc = "Small parts that seemingly once belonged to some sort of a raygun."
-/*
+
 // GS13 fatty liquid beakers defs, for admin stuff and mapping junk
 
-/obj/item/reagent_containers/glass/beaker/lipoifier
+/obj/item/reagent_containers/cup/beaker/lipoifier
 	list_reagents = list(/datum/reagent/consumable/lipoifier = 50)
 
+/obj/item/reagent_containers/cup/beaker/galbanic
+	list_reagents = list(/datum/reagent/fermi_fat = 50)
+
+/*
 /obj/item/reagent_containers/glass/beaker/cornoil
 	list_reagents = list(/datum/reagent/consumable/cornoil = 50)
 
@@ -37,9 +41,6 @@
 
 /obj/item/reagent_containers/glass/beaker/flatulose
 	list_reagents = list(/datum/reagent/consumable/flatulose = 50)
-
-/obj/item/reagent_containers/glass/beaker/galbanic
-	list_reagents = list(/datum/reagent/fermi_fat = 50)
 
 /obj/item/reagent_containers/glass/beaker/macarenic
 	list_reagents = list(/datum/reagent/fermi_slim = 50)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6932,6 +6932,7 @@
 #include "modular_gs\code\modules\overwrites\research.dm"
 #include "modular_gs\code\modules\reagents\chemistry\reagents\blueberry.dm"
 #include "modular_gs\code\modules\reagents\chemistry\reagents\consumable_reagents.dm"
+#include "modular_gs\code\modules\reagents\chemistry\reagents\fermi_fat.dm"
 #include "modular_gs\code\modules\research\designs\nutri_designs\nutritech_tools_designs.dm"
 #include "modular_gs\code\modules\research\designs\nutri_designs\nutritech_weapon_designs.dm"
 #include "modular_gs\code\modules\research\techweb\nutritech_nodes.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6906,6 +6906,7 @@
 #include "modular_gs\code\mechanics\fatness.dm"
 #include "modular_gs\code\mechanics\fatrousal.dm"
 #include "modular_gs\code\mechanics\fattening_trap.dm"
+#include "modular_gs\code\mechanics\permanent_fat.dm"
 #include "modular_gs\code\mechanics\recipes.dm"
 #include "modular_gs\code\mechanics\xwg.dm"
 #include "modular_gs\code\modules\cargo\rebase_packs.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/gs13/fatness.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/gs13/fatness.tsx
@@ -2,6 +2,8 @@ import {
   type Feature,
   FeatureNumberInput,
   type FeatureNumeric,
+  CheckboxInput,
+  type FeatureToggle,
 } from '../../base';
 
 export const starting_fatness: Feature<number> = {
@@ -27,4 +29,17 @@ export const max_weight: Feature<number> = {
   description:
     'What is the maximum weight we want our character to be at? 0 means there will be no weight cap.',
   component: FeatureNumberInput,
+};
+
+
+export const weight_gain_persistent: FeatureToggle = {
+  name: 'Persistent weight',
+  description: 'Endround/cryo weight becomes your new start weight.',
+  component: CheckboxInput,
+};
+
+export const weight_gain_permanent: FeatureToggle = {
+  name: 'Permanent weight',
+  description: 'Persists between round, hard to remove.',
+  component: CheckboxInput,
 };


### PR DESCRIPTION
## About The Pull Request

Adds preference options for persistent and perma weight, tied to individual characters, as well as galbanic compound and macerinic solution. Also fixes addictions not properly advancing.

NOTE: Persistent fat is somewhat bugged - if you go into character preference settings and switch the selected character, the perma/persistent weight will save on the character SELECTED in the character customization menu, rather than the one in game. I may know a solution for this, but I will implement it later if it becomes a big problem. Another thing to note is that while I have more or less tested both galbanic compound and macerinic solution, I have not tested it thoroughly due to lack of time. They should work, but I am not certain about more sneaky bugs.

## Why It's Good For The Game

Bigger fatties with fat that's harder to remove. What's not to like?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Swan
add: ports persistent and permanent weight
add: ports galbanic compound, it's effects, overdose and addiction
add: ports macerinic solution, it's effects and overdose
fix: fixes addictions not properly switching stages
/:cl:
