### PR TITLE
adds a WG prefs tab to the character creation menu

### DIFF
--- a/code/__DEFINES/~~gs_defines/preferences.dm
+++ b/code/__DEFINES/~~gs_defines/preferences.dm
@@ -1,0 +1,2 @@
+// For the WG prefs tab in the character creator
+#define WG_PREFERENCES	"wg_prefs"

--- a/modular_gs/code/modules/client/preferences/fatness_preferences.dm
+++ b/modular_gs/code/modules/client/preferences/fatness_preferences.dm
@@ -1,5 +1,5 @@
 /datum/preference/numeric/starting_fatness
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "starting_fatness"
 	minimum = FATNESS_LEVEL_NONE
@@ -14,7 +14,7 @@
 
 
 /datum/preference/numeric/weight_gain_rate
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "weight_gain_rate"
 	minimum = MIN_PREFS_WEIGHT_GAIN_AND_LOSS_RATE
@@ -29,7 +29,7 @@
 
 
 /datum/preference/numeric/weight_loss_rate
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "weight_loss_rate"
 	minimum = MIN_PREFS_WEIGHT_GAIN_AND_LOSS_RATE
@@ -44,7 +44,7 @@
 
 
 /datum/preference/numeric/max_weight
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "max_weight"
 	minimum = 0
@@ -57,7 +57,7 @@
 
 
 /datum/preference/toggle/weight_gain_persistent
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "weight_gain_persistent"
 	default_value = FALSE
@@ -66,7 +66,7 @@
 	return
 
 /datum/preference/toggle/weight_gain_permanent
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "weight_gain_permanent"
 	default_value = FALSE

--- a/modular_gs/code/modules/client/preferences/helplessness_prefs.dm
+++ b/modular_gs/code/modules/client/preferences/helplessness_prefs.dm
@@ -5,98 +5,98 @@
 	return
 
 /datum/preference/numeric/helplessness/no_movement
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "no_movement"
 	minimum = 0
 	maximum = INFINITY
 
 /datum/preference/numeric/helplessness/clumsy
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "clumsy"
 	minimum = 0
 	maximum = INFINITY
 
 /datum/preference/numeric/helplessness/nearsighted
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "nearsighted"
 	minimum = 0
 	maximum = INFINITY
 
 /datum/preference/numeric/helplessness/hidden_face
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "hidden_face"
 	minimum = 0
 	maximum = INFINITY
 
 /datum/preference/numeric/helplessness/mute
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "mute"
 	minimum = 0
 	maximum = INFINITY
 
 /datum/preference/numeric/helplessness/immobile_arms
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "immobile_arms"
 	minimum = 0
 	maximum = INFINITY
 
 /datum/preference/numeric/helplessness/clothing_jumpsuit
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "clothing_jumpsuit"
 	minimum = 0
 	maximum = INFINITY
 
 /datum/preference/numeric/helplessness/clothing_misc
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "clothing_misc"
 	minimum = 0
 	maximum = INFINITY
 
 /datum/preference/numeric/helplessness/belts
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "belts"
 	minimum = 0
 	maximum = INFINITY
 
 /datum/preference/numeric/helplessness/clothing_back
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "clothing_back"
 	minimum = 0
 	maximum = INFINITY
 
 /datum/preference/numeric/helplessness/no_buckle
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "no_buckle"
 	minimum = 0
 	maximum = INFINITY
 
 /datum/preference/numeric/helplessness/chair_breakage
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "chair_breakage"
 	minimum = 0
 	maximum = INFINITY
 
 /datum/preference/numeric/helplessness/stuckage
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "stuckage"
 	minimum = 0
 	maximum = INFINITY
 
 /datum/preference/numeric/helplessness/stuckage_custom
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	category = WG_PREFERENCES
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "stuckage_custom"
 	minimum = 0

--- a/modular_gs/code/modules/client/preferences/wg_source_preferences.dm
+++ b/modular_gs/code/modules/client/preferences/wg_source_preferences.dm
@@ -1,48 +1,71 @@
 /datum/preference/toggle/weight_gain_food
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	savefile_identifier = PREFERENCE_PLAYER
+	category = WG_PREFERENCES
+	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "weight_gain_food"
 	default_value = FALSE
 
+/datum/preference/toggle/weight_gain_food/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return
+
 /datum/preference/toggle/weight_gain_chems
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	savefile_identifier = PREFERENCE_PLAYER
+	category = WG_PREFERENCES
+	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "weight_gain_chems"
 	default_value = FALSE
 
+/datum/preference/toggle/weight_gain_chems/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return
+
 /datum/preference/toggle/weight_gain_items
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	savefile_identifier = PREFERENCE_PLAYER
+	category = WG_PREFERENCES
+	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "weight_gain_items"
 	default_value = FALSE
 
+/datum/preference/toggle/weight_gain_items/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return
+
 /datum/preference/toggle/weight_gain_weapons
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	savefile_identifier = PREFERENCE_PLAYER
+	category = WG_PREFERENCES
+	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "weight_gain_weapons"
 	default_value = FALSE
 
+/datum/preference/toggle/weight_gain_weapons/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return
+
 /datum/preference/toggle/weight_gain_magic
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	savefile_identifier = PREFERENCE_PLAYER
+	category = WG_PREFERENCES
+	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "weight_gain_magic"
 	default_value = FALSE
 
+/datum/preference/toggle/weight_gain_magic/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return
+
 /datum/preference/toggle/weight_gain_viruses
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	savefile_identifier = PREFERENCE_PLAYER
+	category = WG_PREFERENCES
+	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "weight_gain_viruses"
 	default_value = FALSE
 
+/datum/preference/toggle/weight_gain_viruses/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return
+
 /datum/preference/toggle/weight_gain_nanites
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	savefile_identifier = PREFERENCE_PLAYER
+	category = WG_PREFERENCES
+	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "weight_gain_nanites"
 	default_value = FALSE
 
+/datum/preference/toggle/weight_gain_nanites/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return
+
 /datum/preference/toggle/weight_gain_atmos
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	savefile_identifier = PREFERENCE_PLAYER
+	category = WG_PREFERENCES
+	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "weight_gain_atmos"
 	default_value = FALSE
 
+/datum/preference/toggle/weight_gain_atmos/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/preferences)
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -554,6 +554,7 @@
 #include "code\__DEFINES\~~gs_defines\DNA.dm"
 #include "code\__DEFINES\~~gs_defines\misc.dm"
 #include "code\__DEFINES\~~gs_defines\mobs.dm"
+#include "code\__DEFINES\~~gs_defines\preferences.dm"
 #include "code\__DEFINES\~~gs_defines\signals.dm"
 #include "code\__DEFINES\~~gs_defines\traits.dm"
 #include "code\__HELPERS\_auxtools_api.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
@@ -523,10 +523,16 @@ export function MainPage(props: MainPageProps) {
     delete nonContextualPreferences.random_name;
   }
 
+  // GS13 EDIT
+  const WGPreferences = {
+    ...data.character_preferences.wg_prefs
+  };
+  // GS13 END EDIT
   // BUBBER EDIT ADDITION BEGIN: SWAPPABLE PREF MENUS
   enum PrefPage {
     Visual, // The visual parts
     Lore, // Lore, Flavor Text, Age, Records
+    WGprefs, // GS13 EDIT prefs
   }
 
   const [currentPrefPage, setCurrentPrefPage] = useState(PrefPage.Visual);
@@ -559,6 +565,21 @@ export function MainPage(props: MainPageProps) {
         />
       );
       break;
+      // GS13 EDIT
+      case PrefPage.WGprefs:
+        prefPageContents = (
+        <PreferenceList
+          randomizations={getRandomization(
+            WGPreferences,
+            serverData,
+            randomBodyEnabled,
+          )}
+          preferences={WGPreferences}
+          maxHeight="auto"
+        />
+        );
+        break;
+        // GS13 END EDIT
     default:
       exhaustiveCheck(currentPrefPage);
   }
@@ -719,6 +740,17 @@ export function MainPage(props: MainPageProps) {
                   Character Lore
                 </PageButton>
               </Stack.Item>
+              {/* GS13 EDIT */}
+              <Stack.Item grow={2}>
+                <PageButton
+                  currentPage={currentPrefPage}
+                  page={PrefPage.WGprefs}
+                  setPage={setCurrentPrefPage}
+                >
+                  WG preferences
+                </PageButton>
+              </Stack.Item>
+              {/* GS13 END EDIT */}
             </Stack>
             {prefPageContents}
           </Stack>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/types.ts
@@ -194,6 +194,10 @@ export type PreferencesMenuData = {
     supplemental_features: Record<string, unknown>;
     manually_rendered_features: Record<string, string>;
 
+    // GS13 EDIT
+    wg_prefs: Record<string, unknown>
+    // GS13 END EDIT
+
     names: Record<string, string>;
 
     misc: {


### PR DESCRIPTION
## About The Pull Request

Puts our prefs in a separate tab in the character creator. Also makes WG sources a per character pref

## Why It's Good For The Game

Sorts our prefs and makes WG sources a per character trait

## Changelog

:cl: Swan
qol: Moved our prefs to a new, separate tab in the character creator menu
fix: makes WG sources individual for each character
/:cl:
