### PR TITLE
Exoskeleton rebalancing

### DIFF
--- a/code/modules/research/techweb/nodes/modsuit_nodes.dm
+++ b/code/modules/research/techweb/nodes/modsuit_nodes.dm
@@ -19,6 +19,8 @@
 		"mod_flashlight",
 		//GS13 EDIT START
 		"mod_exoskeleton",
+		"mod_hydraulic",
+		"mod_calovoltaic",
 		//GS13 EDIT END
 	)
 

--- a/modular_gs/code/modules/mod/modules/modules_fat.dm
+++ b/modular_gs/code/modules/mod/modules/modules_fat.dm
@@ -54,7 +54,7 @@
 /datum/design/module/hydraulic_movement
 	name = "Hydraulic Assistance Module"
 	id = "mod_hydraulic"
-	materials = list(/datum/material/iron = 1000, /datum/material/glass = 200)
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*2.5, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT)
 	build_path = /obj/item/mod/module/hydraulic_movement
 	desc = "A GATO-designed module that supports plumper bodies and allows easier movement."
 
@@ -95,7 +95,7 @@
 /datum/design/module/calovoltaic
 	name = "Calovoltaic Generator Module"
 	id = "mod_calovoltaic"
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 500, /datum/material/plasma = 500)
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2.5, /datum/material/glass = SHEET_MATERIAL_AMOUNT * 2.5, /datum/material/plasma = SHEET_MATERIAL_AMOUNT * 2.5)
 	build_path = /obj/item/mod/module/calovoltaic
 	desc = "A GATO-designed module for burning excess fat to make power for your suit."
 
@@ -208,7 +208,7 @@
 /obj/item/mod/control/pre_equipped/exoskeleton
 	desc = "A pre-built GATO mobility exoskeleton, designed to support high weights, favor movement and weight loss."
 	theme = /datum/mod_theme/exoskeleton
-	core = /obj/item/mod/core/standard
+	applied_cell = /obj/item/stock_parts/power_store/cell/high
 
 /obj/item/mod/control/pre_equipped/exoskeleton/locked
 	name = "MOD control unit (locked)"
@@ -219,7 +219,7 @@
 	name = "MOD exoskeleton"
 	desc = "A pre-built GATO mobility exoskeleton, designed to support high weights, favor movement and weight loss."
 	id = "mod_exoskeleton"
-	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*50, /datum/material/glass = SHEET_MATERIAL_AMOUNT*50, /datum/material/plasma = SHEET_MATERIAL_AMOUNT*50)
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*10, /datum/material/glass = SHEET_MATERIAL_AMOUNT*5, /datum/material/plasma = SHEET_MATERIAL_AMOUNT*2.5)
 	build_path = /obj/item/mod/control/pre_equipped/exoskeleton
 	desc = "A GATO-designed assistance exoskeleton based on MODsuit tech."
 	build_type = MECHFAB


### PR DESCRIPTION

## About The Pull Request

Rebalances the exoskeleton's price and also makes available the calovoltaic generator and hydraulic movement assistance modules. Exoskeleton cost was a sum of its parts as well as an additional cost added atop that.
<img width="412" height="253" alt="image" src="https://github.com/user-attachments/assets/5c4089d4-d796-4b3f-882c-9d860732e619" />
<img width="427" height="184" alt="image" src="https://github.com/user-attachments/assets/cbdf559a-78d8-4a0c-bf98-e2e57dc00bed" />
## Why It's Good For The Game

This makes the Exoskeleton more accessible and makes the individual modules accessible. This latter detail is an oversight of mine.
## Proof Of Testing
heres the screenies of em all printed out
<details>
<summary>Screenshots/Videos</summary>
<img width="152" height="64" alt="image" src="https://github.com/user-attachments/assets/f0efb89c-c000-4630-8189-95866541a16f" />

</details>

## Changelog
:cl:
fix: you can now print calovoltaic generator modules and hydraulic assistance modules
balance: the mod exoskeleton is cheaper
/:cl:
