### PR TITLE
Slime Eater quirk text, blueberry color, permaberry amount and juicing

### DIFF
--- a/modular_gs/code/datums/quirks/negative/negative_quirks.dm
+++ b/modular_gs/code/datums/quirks/negative/negative_quirks.dm
@@ -158,5 +158,5 @@
 	var/time_passed = 0
 
 /datum/quirk/permaberry/process(seconds_per_tick)
-		quirk_holder.reagents.add_reagent(/datum/reagent/blueberry_juice, 0.05 + min(0.15, (time_passed / 48000)))
-		time_passed += seconds_per_tick
+	quirk_holder.reagents.add_reagent(/datum/reagent/blueberry_juice, (0.01 + min(0.49, (time_passed / 14693))) * seconds_per_tick)
+	time_passed += seconds_per_tick

--- a/modular_gs/code/datums/quirks/positive/positive_quirks.dm
+++ b/modular_gs/code/datums/quirks/positive/positive_quirks.dm
@@ -153,7 +153,7 @@
 
 /datum/quirk/slime_eater
 	name = "Slime eater"
-	desc = "Slimes make your mouth water! You can safely metabolize slime jelly for nutrition and can gobble up a xenobiology slime you are aggressively grabbing!"
+	desc = "Slimes make your mouth water! You can safely metabolize slime jelly for nutrition and can gobble up a xenobiology slime you are aggressively grabbing with Ctrl + LMB!"
 	icon = "fa-shield"
 	medical_record_text = "Patient's digestive system is able to process slime jelly."
 	value = 1

--- a/modular_gs/code/modules/reagents/chemistry/reagents/blueberry.dm
+++ b/modular_gs/code/modules/reagents/chemistry/reagents/blueberry.dm
@@ -6,8 +6,8 @@
 	//reagent_state = LIQUID
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	color = "#0004ff"
-	var/picked_color
-	var/list/random_color_list = list("#0058db","#5d00c7","#0004ff","#0057e7")
+	var/mob_color = "#0004ff"
+	//var/list/random_color_list = list("#0058db","#5d00c7","#0004ff","#0057e7")
 	taste_description = "blueberry pie"
 	var/no_mob_color = FALSE
 	// put this back in later value = 10	//it sells. Make that berry factory
@@ -19,8 +19,8 @@
 			M.reagents.remove_reagent(/datum/reagent/blueberry_juice, volume)
 			return
 		if(!no_mob_color)
-			M.add_atom_colour(picked_color, WASHABLE_COLOUR_PRIORITY)
-		M.adjust_fatness(1, FATTENING_TYPE_CHEM)
+			M.add_atom_colour(color, WASHABLE_COLOUR_PRIORITY)
+		//M.adjust_fatness(1, FATTENING_TYPE_CHEM)
 	if(volume >= 999)
 		M.add_quirk(/datum/quirk/permaberry)
 	..()
@@ -31,7 +31,6 @@
 		if(!affected_mob?.client || !(affected_mob?.client?.prefs?.read_preference(/datum/preference/toggle/blueberry_inflation)))
 			affected_mob.reagents.remove_reagent(/datum/reagent/blueberry_juice, volume)
 			return
-		picked_color = pick(random_color_list)
 		affected_mob.hider_add(src)
 	else
 		L.reagents.remove_reagent(/datum/reagent/blueberry_juice, volume)


### PR DESCRIPTION
-Slime Eater's description now includes instructions on how it's used to eat slimes
-Color of berry juice is now static
-Permaberry production over time reduced early and ramps up over 2 hours (from 0.01u to 0.5u every second)
-Juicing someone with blueberry juice in them is now down with a right click and repeats the action