### PR TITLE
Lipoplant additions

### DIFF
--- a/modular_gs/code/modules/hydroponics/lipoplant.dm
+++ b/modular_gs/code/modules/hydroponics/lipoplant.dm
@@ -9,7 +9,7 @@
 	maturation = 8
 	production = 5
 	yield = 1
-	reagents_add = list(/datum/reagent/consumable/lipoifier = 0.05)
+	reagents_add = list(/datum/reagent/consumable/lipoifier = 0.2)
 	icon = 'modular_gs/icons/obj/hydroponics/seeds.dmi'
 	icon_state = "seed-lipo"
 	growing_icon = 'modular_gs/icons/obj/hydroponics/growing.dmi'
@@ -23,26 +23,15 @@
 	desc = "A foreign fruit with an hard shell. Perhaps something sharp could open it?"
 	icon = 'modular_gs/icons/obj/hydroponics/harvest.dmi'
 	icon_state = "lipo_nut"
-	item_state = "lipo_nut"
-	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30, 50)
-	spillable = FALSE
 	resistance_flags = ACID_PROOF
-	volume = 150 //so it won't cut reagents despite having the capacity for them
 	w_class = WEIGHT_CLASS_SMALL
-	force = 5
-	throwforce = 5
-	hitsound = 'sound/weapons/klonk.ogg'
-	attack_verb = list("klonked", "donked", "bonked")
 	distill_reagent = "creme_de_coconut"
 	var/opened = FALSE
-
+/*
 /obj/item/food/grown/lipofruit/attackby(obj/item/W, mob/user, params)
 	if(!opened && W.sharpness)
 		user.show_message("<span class='notice'>You slice the fruit open!</span>", 1)
 		opened = TRUE
-		spillable = TRUE
-		reagent_flags = OPENCONTAINER
-		reagents.reagents_holder_flags |= OPENCONTAINER
 		icon_state = "lipo_nutcut_full"
 		desc = "A foreign fruit with an hard shell, the liquid inside looks very inviting."
 		playsound(user, W.hitsound, 50, 1, -1)
@@ -51,8 +40,6 @@
 
 /obj/item/food/grown/lipofruit/attack(mob/living/M, mob/user, obj/target)
 	if(!opened)
-		return
-	if(!canconsume(M, user))
 		return
 	if(!reagents || !reagents.total_volume)
 		to_chat(user, "<span class='warning'>[src] is empty!</span>")
@@ -124,3 +111,4 @@
 		icon_state = "lipo_nutcut_full"
 		desc = "A foreign fruit with an hard shell, the liquid inside looks very inviting."
 
+*/

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6994,6 +6994,7 @@
 #include "modular_gs\code\modules\gym\gym.dm"
 #include "modular_gs\code\modules\hud\alert.dm"
 #include "modular_gs\code\modules\hud\BFI.dm"
+#include "modular_gs\code\modules\hydroponics\lipoplant.dm"
 #include "modular_gs\code\modules\hydroponics\munchies_weed.dm"
 #include "modular_gs\code\modules\hydroponics\grown\berries.dm"
 #include "modular_gs\code\modules\loadout\belt.dm"


### PR DESCRIPTION

## About The Pull Request

Re-implements the code for lipoplant at a base level so alphas can add it to xenoarch. 
## Why It's Good For The Game

Botany still lacks a way to have fat plants outside of xenoarch, this begins the process of reimplementing them into bubbercode. Currently this doesn't have a way for players to obtain it since xenoarch is still wip, but admins can spawn it.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

<img width="480" height="622" alt="image_2025-11-28_192717911" src="https://github.com/user-attachments/assets/3b086d0d-f642-4ab1-b2f8-7027e5e02a34" />

</details>

## Changelog
:cl:
add: Added Adipolipus plants to codebase with a 20% lipo gene.
/:cl:
