### PR TITLE
Lipo/Galba/MCalorite synthesis flags

### DIFF
--- a/modular_gs/code/modules/reagents/chemistry/reagents/blueberry.dm
+++ b/modular_gs/code/modules/reagents/chemistry/reagents/blueberry.dm
@@ -12,6 +12,7 @@
 	var/no_mob_color = FALSE
 	// put this back in later value = 10	//it sells. Make that berry factory
 	purge_multiplier = 3
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/blueberry_juice/on_mob_life(mob/living/carbon/M)
 	if(M?.client)

--- a/modular_gs/code/modules/reagents/chemistry/reagents/consumable_reagents.dm
+++ b/modular_gs/code/modules/reagents/chemistry/reagents/consumable_reagents.dm
@@ -9,6 +9,7 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	process_flags = REAGENT_ORGANIC | REAGENT_SYNTHETIC | REAGENT_PROTEAN // Allow all kinds of humanoids to process the chem
 	var/fat_to_add = 15
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/consumable/lipoifier/on_mob_life(mob/living/carbon/M)
 	M.adjust_fatness(fat_to_add, FATTENING_TYPE_CHEM)
@@ -103,6 +104,7 @@
 	name = "Weak lipoifier"
 	description = "A weaker variant of lipoifier. Causes those that ingest it to build up fat cells."
 	fat_to_add = 6
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/micro_calorite
 	name = "Micro calorite"
@@ -111,6 +113,7 @@
 	taste_description = "sugar"
 	metabolization_rate = 0.01	// just absolutely fuck them up
 	overdose_threshold = 100
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/micro_calorite/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
@@ -138,7 +141,7 @@
 	..()
 	if (!iscarbon(affected_mob))
 		return
-	
+
 	var/mob/living/carbon/affected_carbon = affected_mob
 	affected_carbon.add_weight_gain_modifier("micro_calorite", 0.6)
 	affected_carbon.add_weight_loss_modifier("micro_calorite", -0.6)
@@ -146,6 +149,6 @@
 /datum/reagent/micro_calorite/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
 	if (!iscarbon(affected_mob))
 		return
-	
+
 	var/mob/living/carbon/affected_carbon = affected_mob
 	affected_carbon.adjust_fatness(5, FATTENING_TYPE_CHEM)

--- a/modular_gs/code/modules/reagents/chemistry/reagents/fermi_fat.dm
+++ b/modular_gs/code/modules/reagents/chemistry/reagents/fermi_fat.dm
@@ -9,6 +9,7 @@
 	overdose_threshold = 50
 	addiction_types = list(/datum/addiction/fermi_fat = 4)
 	process_flags = REAGENT_ORGANIC | REAGENT_SYNTHETIC | REAGENT_PROTEAN // Allow all kinds of humanoids to process the chem
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 
 //Reaction
@@ -127,6 +128,7 @@
 	metabolization_rate = REAGENTS_METABOLISM / 2
 	overdose_threshold = 50
 	process_flags = REAGENT_ORGANIC | REAGENT_SYNTHETIC | REAGENT_PROTEAN // Allow all kinds of humanoids to process the chem
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 //Reaction
 /datum/chemical_reaction/fermi_slim


### PR DESCRIPTION

## About The Pull Request

Adds the can be synthesized flag to lipoifier, galbanic, macernic and micro-calorite, allowing them to appear in plant genomes as well as be injected into bees to be made into honey.
## Why It's Good For The Game

Botany lacks a way to produce fat chems outside of Adipolipus which aren't implemented yet, this allows it to be a random strange seed genome as well as a production pathway through bees.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="510" height="73" alt="image_2025-11-28_195548899" src="https://github.com/user-attachments/assets/73e66142-e9ae-4985-be97-aeb16a6fb8ca" />


</details>

## Changelog
:cl:
add: Added the ability for plants and bees to produce lipoifier, micro-calorite, weak lipoifier, macernic and galbanic through their respective genome modification pathways.
/:cl:
