### PR TITLE
add a motorized bed

### DIFF
--- a/modular_gs/code/modules/vehicles/motorized_bed.dm
+++ b/modular_gs/code/modules/vehicles/motorized_bed.dm
@@ -1,0 +1,25 @@
+/obj/vehicle/ridden/wheelchair/motorized/motorized_bed
+	buckle_lying = 90
+	buckle_dir = SOUTH
+	icon = 'icons/obj/medical/medical_bed.dmi'
+	icon_state = "med_down"
+	base_icon_state = "med"
+
+/obj/vehicle/ridden/wheelchair/motorized/motorized_bed/make_ridable()
+	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/wheelchair/hand)
+	//necessary because adding the element sets buckle_lying to 0 again
+	buckle_lying = 90
+	buckle_dir = SOUTH
+
+/obj/vehicle/ridden/wheelchair/motorized/motorized_bed/Initialize(mapload)
+	. = ..()
+	var/datum/component/simple_rotation = src.GetComponent(/datum/component/simple_rotation)
+	simple_rotation.Destroy()
+	icon_state = "med_down"
+
+/obj/vehicle/ridden/wheelchair/motorized/motorized_bed/refresh_parts()
+	speed = 1 // Should never be under 1
+	for(var/datum/stock_part/servo/servo in component_parts)
+		speed += servo.tier
+	for(var/datum/stock_part/capacitor/capacitor in component_parts)
+		power_efficiency = capacitor.tier

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7044,6 +7044,7 @@
 #include "modular_gs\code\modules\research\techweb\nutritech_nodes.dm"
 #include "modular_gs\code\modules\storyteller\storytellers\tellers\storyteller_7_relaxed.dm"
 #include "modular_gs\code\modules\surgery\organs\internal\stomach\stomach_ethereal.dm"
+#include "modular_gs\code\modules\vehicles\motorized_bed.dm"
 #include "modular_gs\code\modules\vending\gs_vendors.dm"
 #include "modular_gs\code\modules\vending\vending.dm"
 #include "modular_gs\code\modules\vending\wardrobes.dm"


### PR DESCRIPTION
adds a bed that's motorized. code-wise it's functionally a motorized wheelchair, except the character is set to lay down on it instead of sit up
## About The Pull Request

Adds a motorized bed which would be fitting for people who are extra large and may need extra support when traversing the station. An alternative to wheelchairs.

Currently has issues with rotation, which is why this is a draft.
## Why It's Good For The Game

I think it's pretty fitting flavor-wise to add this motorized bed to this codebase. It's something I feel was missing, since some people might be too large for wheelchairs.
## Proof Of Testing

Tested in game for sprites and functionality, but currently WIP as there are previously-mentioned rotational issues- essentially the character looks like they're rolling around on the bed when it moves. Also somewhat WIP are the sprites- currently it uses the medical bed sprites but I'd like to at least customize those before this is finalized.
<details>
<summary>Screenshots/Videos</summary>

</details>

## Changelog
:cl:
add: a motorized bed that allows people to move it around while laying down on it
/:cl:
