### PR TITLE
fix: fitness examine text showing up with fat stages instead of muscle stages.

### DIFF
--- a/modular_gs/code/modules/mob/living/carbon/examine.dm
+++ b/modular_gs/code/modules/mob/living/carbon/examine.dm
@@ -87,63 +87,63 @@
 	*/
 	var/ws_text
 
-	if(fatness >= FATNESS_LEVEL_BLOB)
+	if(muscle >= FATNESS_LEVEL_BLOB)
 		ws_text = dna?.features["ms_mountainous"]
 		if(ws_text)
 			return ws_text
 
 		//return "[t_He] [t_is] completely engulfed in rolls upon rolls of flab. [t_His] head is poking out on top of [t_His] body, akin to a marble on top of a hill.\n"
 
-	if(fatness >= FATNESS_LEVEL_IMMOBILE)
+	if(muscle >= FATNESS_LEVEL_IMMOBILE)
 		ws_text = dna?.features["ms_titanic"]
 		if(ws_text)
 			return ws_text
 
 		//return "[t_His] body is buried in an overflowing surplus of adipose, and [t_His] legs are completely buried beneath layers of meaty, obese flesh.\n"
 
-	if(fatness >= FATNESS_LEVEL_BARELYMOBILE)
+	if(muscle >= FATNESS_LEVEL_BARELYMOBILE)
 		ws_text = dna?.features["ms_hulking"]
 		if(ws_text)
 			return ws_text
 
 		//return "[t_He] [t_is] as wide as [t_He] [t_is] tall, barely able to move [t_His] masssive body that seems to be overtaken with piles of flab.\n"
 
-	if(fatness >= FATNESS_LEVEL_EXTREMELY_OBESE)
+	if(muscle >= FATNESS_LEVEL_EXTREMELY_OBESE)
 		ws_text = dna?.features["ms_herculean"]
 		if(ws_text)
 			return ws_text
 
 		//return "[t_He] [t_is] ripe with numerous rolls of fat, almost all of [t_His] body layered with adipose.\n"
 
-	if(fatness >= FATNESS_LEVEL_MORBIDLY_OBESE)
+	if(muscle >= FATNESS_LEVEL_MORBIDLY_OBESE)
 		ws_text = dna?.features["ms_beefy"]
 		if(ws_text)
 			return ws_text
 
 		//return "[t_He] [t_is] utterly stuffed with abundant lard, [t_He] doesn't seem to be able to move much.\n"
 
-	if(fatness >= FATNESS_LEVEL_OBESE)
+	if(muscle >= FATNESS_LEVEL_OBESE)
 		ws_text = dna?.features["ms_muscular"]
 		if(ws_text)
 			return ws_text
 
 		//return "[t_He] [t_is] engorged with fat, [t_His] body laden in rolls of fattened flesh.\n"
 
-	if(fatness >= FATNESS_LEVEL_VERYFAT)
+	if(muscle >= FATNESS_LEVEL_VERYFAT)
 		ws_text = dna?.features["ms_athletic"]
 		if(ws_text)
 			return ws_text
 
 		//return "[t_He] [t_is] pleasantly plushy, [t_His] body gently wobbling whenever they move. \n"
 
-	if(fatness >= FATNESS_LEVEL_FATTER)
+	if(muscle >= FATNESS_LEVEL_FATTER)
 		ws_text = dna?.features["ms_sporty"]
 		if(ws_text)
 			return ws_text
 
 		//return "[t_He] [t_is] soft and curvy, [t_His] belly looking like a small pillow.\n"
 
-	if(fatness >= FATNESS_LEVEL_FAT)
+	if(muscle >= FATNESS_LEVEL_FAT)
 		ws_text = dna?.features["ms_toned"]
 		if(ws_text)
 			return ws_text


### PR DESCRIPTION
## About The Pull Request

This Change effects the examine.dm file, which was previously checking the fatness variable when it should have been checking muscle

 this change was tested on the runtime map, and gave me no errors. increasing the muscle variable gave the relevant examines and increasing the fatness variable gave it's relevant examines.

## Why It's Good For The Game

I think this is good for the game becuase fit characters need to exist to contrast agaisnt fat characters.


## Changelog

:cl:
fix: Fixes player muscle examines showing up with player fat examines
/:cl:
