### PR TITLE
making nitrogen be consumed alongside oxygen when breathed

### DIFF
--- a/modular_gs/code/modules/surgery/organs/internal/lungs.dm
+++ b/modular_gs/code/modules/surgery/organs/internal/lungs.dm
@@ -1,0 +1,8 @@
+/obj/item/organ/lungs/Initialize(mapload)
+	. = ..()
+	if(!safe_nitro_min)
+		add_gas_reaction(/datum/gas/nitrogen, while_present = PROC_REF(consume_nitrogen))
+
+// removes all N2 from the breath. This makes it so that players will no longer suffocate in dorms.
+/obj/item/organ/lungs/proc/consume_nitrogen(mob/living/carbon/breather, datum/gas_mixture/breath, nitrogen_pp, old_nitrogen_pp)
+	breathe_gas_volume(breath, /datum/gas/nitrogen)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7107,6 +7107,7 @@
 #include "modular_gs\code\modules\research\nanites\nanite_programs\fattening.dm"
 #include "modular_gs\code\modules\research\techweb\nutritech_nodes.dm"
 #include "modular_gs\code\modules\storyteller\storytellers\tellers\storyteller_7_relaxed.dm"
+#include "modular_gs\code\modules\surgery\organs\internal\lungs.dm"
 #include "modular_gs\code\modules\surgery\organs\internal\stomach\stomach_ethereal.dm"
 #include "modular_gs\code\modules\vending\gs_vendors.dm"
 #include "modular_gs\code\modules\vending\vending.dm"


### PR DESCRIPTION
## About The Pull Request

Adds logic to consume nitrogen alongside nitrogen when breathed. This should make it so that players no longer suffocate in well ventilated rooms. This does not make nitrogen necessary to breathe - it just makes it so that it is removed when a player breathes it

## Why It's Good For The Game

closes #224 

We have had many cases of players dying when sleeping in dorms. This should stop it completely, or at the very least make it take such a long time that it isn't a concern even during our very long rounds.

## Changelog

:cl: Swan
add: nitrogen is now consumed alongside oxygen when breathing. You don't need nitrogen to breathe, but this should prevent it from slowly filling up the room and causing players to suffocate
/:cl: