### PR TITLE
Make it so that canes reduce fat slowdown

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -664,7 +664,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	attack_verb_continuous = list("bludgeons", "whacks", "disciplines", "thrashes")
 	attack_verb_simple = list("bludgeon", "whack", "discipline", "thrash")
 	//GS13 EDIT
-	var/amount = -1
+	var/fatness_slowdown_reduction = -1
 	//GS13 EDIT END
 
 /obj/item/cane/examine(mob/user, thats)
@@ -688,7 +688,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	//GS13 EDIT
 	var/mob/living/carbon/fatty = user
 	if(istype(fatty))
-		fatty.add_fat_delay_modifier("cane", amount)
+		fatty.add_fat_delay_modifier("cane", fatness_slowdown_reduction)
 	//GS13 EDIT END
 	return TRUE
 
@@ -721,7 +721,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	attack_verb_continuous = list("bludgeons", "whacks", "thrashes")
 	attack_verb_simple = list("bludgeon", "whack", "thrash")
 	//GS13 EDIT
-	amount = -2
+	fatness_slowdown_reduction = -2
 	//GS13 EDIT END
 
 /obj/item/cane/crutch/Initialize(mapload)


### PR DESCRIPTION
Canes now add a fat delay modifier, which reduces the slowdown from being overweight.
## About The Pull Request

Adds a bit to canes and crutches where they now reduce fatness slowdown while you hold them.
## Why It's Good For The Game

We need more ways for people to help with overweightness. Adding this trait to canes and crutches gives them more use, and also encourages people to make fashionable choices for their characters.
## Proof Of Testing

I compiled it and ran it locally. Holding a cane makes it so that you move slightly less slow from overweightness.

There is a bug where if you hold two canes, dropping one of them will remove the slowness of the other cane, but this seems to be a bug with the default cane/crutch behaviors as well, as dropping one of them triggers the proc that removes the benefits of the cane/crutch. Just don't use two canes/crutches.
<details>
<summary>Screenshots/Videos</summary>
<img width="395" height="28" alt="image" src="https://github.com/user-attachments/assets/fe3b2355-840f-4c05-854e-cab275f64860" />

</details>

## Changelog
:cl:
balance: canes and crutches now help you move around while overweight
/:cl:
