### PR TITLE
adds tauric weight scaling

### DIFF
--- a/modular_gs/code/modules/mob/living/carbon/weight_helpers.dm
+++ b/modular_gs/code/modules/mob/living/carbon/weight_helpers.dm
@@ -16,5 +16,8 @@
 	return round(((muscle*MUSCLE_TO_WEIGHT_RATIO)) * (dna.current_body_size ** 2))
 
 /mob/living/carbon/proc/calculate_weight_in_pounds()
-	return (calculate_total_fatness_weight_in_pounds() + calculate_total_muscle_weight_in_pounds() + (BASE_WEIGHT_VALUE * (dna.current_body_size ** 2))) *((dna.mutant_bodyparts[FEATURE_TAUR] && dna.mutant_bodyparts[FEATURE_TAUR][MUTANT_INDEX_NAME] != "None") ? 2.5 : 1)
+	var/fatness_and_muscle_weight = (calculate_total_fatness_weight_in_pounds() + calculate_total_muscle_weight_in_pounds())
+	var/base_body_weight = (BASE_WEIGHT_VALUE * (dna.current_body_size ** 2))
+	var/tauric_weight_multiplier = ((dna.mutant_bodyparts[FEATURE_TAUR] && dna.mutant_bodyparts[FEATURE_TAUR][MUTANT_INDEX_NAME] != "None") ? 2.5 : 1)
+	return (fatness_and_muscle_weight + base_body_weight) * tauric_weight_multiplier
 


### PR DESCRIPTION

## About The Pull Request

Taurs get a 2.5x weight multiplier because they have more body per body. At 0 BFI, they start at 350 pounds, because they have approximately 2.5x bodies per body.
## Why It's Good For The Game

This is awesome for the game, because it makes me feel better when I play a tauric character. BFI scales with height, and this is like giving someone extra height horizontally.

Plus it's a feature we had in citbase.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>

Tauric weights:
<img width="485" height="63" alt="image" src="https://github.com/user-attachments/assets/db8f3728-b742-4b15-8c83-e135c8b1f480" />
<img width="517" height="72" alt="image" src="https://github.com/user-attachments/assets/b45cb14b-fd30-43a1-8638-b6118d893060" />

Non-tauric weights:
<img width="492" height="67" alt="image" src="https://github.com/user-attachments/assets/ce9abad0-669f-4929-a1ef-0f2304801d90" />
<img width="501" height="63" alt="image" src="https://github.com/user-attachments/assets/3c26633f-0d2b-4486-bd95-f547cc4dfbd3" />


</details>

## Changelog
:cl:
balance: Taurs now get a weight multiplier to account for extra body mass.
/:cl:
