### PR TITLE
fixes tauric weight calculations

### DIFF
--- a/modular_gs/code/modules/mob/living/carbon/weight_helpers.dm
+++ b/modular_gs/code/modules/mob/living/carbon/weight_helpers.dm
@@ -1,23 +1,27 @@
 /// Calculates how much fatness_to_calculate would be in pounds.
 /mob/living/carbon/proc/calculate_fatness_weight_in_pounds(fatness_to_calculate)
-	return round(((fatness_to_calculate*FATNESS_TO_WEIGHT_RATIO)) * (dna.current_body_size ** 2))
+	var/tauric_weight_multiplier = ((dna.mutant_bodyparts[FEATURE_TAUR] && dna.mutant_bodyparts[FEATURE_TAUR][MUTANT_INDEX_NAME] != "None") ? 2.5 : 1)
+	return round(((fatness_to_calculate*FATNESS_TO_WEIGHT_RATIO)) * (dna.current_body_size ** 2)) *tauric_weight_multiplier
 
 /// Returns the weight of all of the mob's fatness in pounds.
 /mob/living/carbon/proc/calculate_total_fatness_weight_in_pounds()
-	return round(((fatness*FATNESS_TO_WEIGHT_RATIO)) * (dna.current_body_size ** 2))	// huff, being bigger really does raise the number on that scale by quite a bit huh~?
+	var/tauric_weight_multiplier = ((dna.mutant_bodyparts[FEATURE_TAUR] && dna.mutant_bodyparts[FEATURE_TAUR][MUTANT_INDEX_NAME] != "None") ? 2.5 : 1)
+	return round(((fatness*FATNESS_TO_WEIGHT_RATIO)) * (dna.current_body_size ** 2)) *tauric_weight_multiplier	// huff, being bigger really does raise the number on that scale by quite a bit huh~?
 	//return round((140 + (fatness*FATNESS_TO_WEIGHT_RATIO))*(size_multiplier**2)*((dna.features["taur"] != "None") ? 2.5: 1))
 
 /// Calculates how much muscle_to_calculate would be in pounds.
 /mob/living/carbon/proc/calculate_muscle_weight_in_pounds(muscle_to_calculate)
-	return round(((muscle_to_calculate*MUSCLE_TO_WEIGHT_RATIO)) * (dna.current_body_size ** 2))
+	var/tauric_weight_multiplier = ((dna.mutant_bodyparts[FEATURE_TAUR] && dna.mutant_bodyparts[FEATURE_TAUR][MUTANT_INDEX_NAME] != "None") ? 2.5 : 1)
+	return round(((muscle_to_calculate*MUSCLE_TO_WEIGHT_RATIO)) * (dna.current_body_size ** 2)) *tauric_weight_multiplier
 
 /// Returns the weight of all of the mob's muscles in pounds.
 /mob/living/carbon/proc/calculate_total_muscle_weight_in_pounds()
-	return round(((muscle*MUSCLE_TO_WEIGHT_RATIO)) * (dna.current_body_size ** 2))
+	var/tauric_weight_multiplier = ((dna.mutant_bodyparts[FEATURE_TAUR] && dna.mutant_bodyparts[FEATURE_TAUR][MUTANT_INDEX_NAME] != "None") ? 2.5 : 1)
+	return round(((muscle*MUSCLE_TO_WEIGHT_RATIO)) * (dna.current_body_size ** 2)) *tauric_weight_multiplier
 
 /mob/living/carbon/proc/calculate_weight_in_pounds()
 	var/fatness_and_muscle_weight = (calculate_total_fatness_weight_in_pounds() + calculate_total_muscle_weight_in_pounds())
-	var/base_body_weight = (BASE_WEIGHT_VALUE * (dna.current_body_size ** 2))
 	var/tauric_weight_multiplier = ((dna.mutant_bodyparts[FEATURE_TAUR] && dna.mutant_bodyparts[FEATURE_TAUR][MUTANT_INDEX_NAME] != "None") ? 2.5 : 1)
-	return (fatness_and_muscle_weight + base_body_weight) * tauric_weight_multiplier
+	var/base_body_weight = (BASE_WEIGHT_VALUE * (dna.current_body_size ** 2)) * tauric_weight_multiplier
+	return fatness_and_muscle_weight + base_body_weight
 


### PR DESCRIPTION

## About The Pull Request

Tauric multiplier was only being added at the end, but this leads to the total weight not being the sum of its parts. This correctly refactors it so now all parts are multiplied separately, and will add to the result.
## Why It's Good For The Game

Calculations being correct is good.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="481" height="321" alt="image" src="https://github.com/user-attachments/assets/19f74df5-938d-4642-95aa-e86a3c8cdc3a" />

</details>

## Changelog
:cl:
fix: fixed tauric weight multiplier
/:cl:
