### PR TITLE
brings back the hilbert hotel

### DIFF
--- a/_maps/map_files/generic/CentCom_skyrat_z2.dmm
+++ b/_maps/map_files/generic/CentCom_skyrat_z2.dmm
@@ -20959,6 +20959,10 @@
 /obj/effect/landmark/latejoin,
 /turf/open/floor/iron/large,
 /area/centcom/interlink)
+"unR" = (
+/obj/machinery/cafe_condo_teleporter,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding/cafe)
 "uos" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
@@ -72266,7 +72270,7 @@ ajx
 aUo
 aUo
 aUo
-aUo
+unR
 aqf
 vTT
 pqy


### PR DESCRIPTION
## About The Pull Request

The hilbert hotel is now a teleporter. I put it in the same place the original hilbert hotel orb was.

## Why It's Good For The Game

Hot steamy ERP in my own private little appartment. If only there was somebody that I could use it with though. Big salt from a coder who gets no bitches.

Closes #329 

## Changelog

:cl: Swan
fix: Brings back the hilbert hotel
/:cl: