### PR TITLE
Make taurs have properly rounded weight.

### DIFF
--- a/modular_gs/code/modules/mob/living/carbon/weight_helpers.dm
+++ b/modular_gs/code/modules/mob/living/carbon/weight_helpers.dm
@@ -1,23 +1,23 @@
 /// Calculates how much fatness_to_calculate would be in pounds.
 /mob/living/carbon/proc/calculate_fatness_weight_in_pounds(fatness_to_calculate)
 	var/tauric_weight_multiplier = ((dna.mutant_bodyparts[FEATURE_TAUR] && dna.mutant_bodyparts[FEATURE_TAUR][MUTANT_INDEX_NAME] != "None") ? 2.5 : 1)
-	return round(((fatness_to_calculate*FATNESS_TO_WEIGHT_RATIO)) * (dna.current_body_size ** 2) *tauric_weight_multiplier)
+	return round((fatness_to_calculate*FATNESS_TO_WEIGHT_RATIO) * (dna.current_body_size ** 2) *tauric_weight_multiplier)
 
 /// Returns the weight of all of the mob's fatness in pounds.
 /mob/living/carbon/proc/calculate_total_fatness_weight_in_pounds()
 	var/tauric_weight_multiplier = ((dna.mutant_bodyparts[FEATURE_TAUR] && dna.mutant_bodyparts[FEATURE_TAUR][MUTANT_INDEX_NAME] != "None") ? 2.5 : 1)
-	return round(((fatness*FATNESS_TO_WEIGHT_RATIO)) * (dna.current_body_size ** 2) *tauric_weight_multiplier)	// huff, being bigger really does raise the number on that scale by quite a bit huh~?
+	return round((fatness*FATNESS_TO_WEIGHT_RATIO) * (dna.current_body_size ** 2) *tauric_weight_multiplier)	// huff, being bigger really does raise the number on that scale by quite a bit huh~?
 	//return round((140 + (fatness*FATNESS_TO_WEIGHT_RATIO))*(size_multiplier**2)*((dna.features["taur"] != "None") ? 2.5: 1))
 
 /// Calculates how much muscle_to_calculate would be in pounds.
 /mob/living/carbon/proc/calculate_muscle_weight_in_pounds(muscle_to_calculate)
 	var/tauric_weight_multiplier = ((dna.mutant_bodyparts[FEATURE_TAUR] && dna.mutant_bodyparts[FEATURE_TAUR][MUTANT_INDEX_NAME] != "None") ? 2.5 : 1)
-	return round(((muscle_to_calculate*MUSCLE_TO_WEIGHT_RATIO)) * (dna.current_body_size ** 2) *tauric_weight_multiplier)
+	return round((muscle_to_calculate*MUSCLE_TO_WEIGHT_RATIO) * (dna.current_body_size ** 2) *tauric_weight_multiplier)
 
 /// Returns the weight of all of the mob's muscles in pounds.
 /mob/living/carbon/proc/calculate_total_muscle_weight_in_pounds()
 	var/tauric_weight_multiplier = ((dna.mutant_bodyparts[FEATURE_TAUR] && dna.mutant_bodyparts[FEATURE_TAUR][MUTANT_INDEX_NAME] != "None") ? 2.5 : 1)
-	return round(((muscle*MUSCLE_TO_WEIGHT_RATIO)) * (dna.current_body_size ** 2) *tauric_weight_multiplier)
+	return round((muscle*MUSCLE_TO_WEIGHT_RATIO) * (dna.current_body_size ** 2) *tauric_weight_multiplier)
 
 /mob/living/carbon/proc/calculate_weight_in_pounds()
 	var/fatness_and_muscle_weight = (calculate_total_fatness_weight_in_pounds() + calculate_total_muscle_weight_in_pounds())


### PR DESCRIPTION

## About The Pull Request

The parentheses on the weight calculations were messed up. This fixes that by wrapping the parentheses for the round() call around the tauric weight multiplier.
## Why It's Good For The Game

Good math and good parentheses are good, and this is consistent with prior calculation of weight - the number is rounded always before displayed to the player.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="505" height="595" alt="image" src="https://github.com/user-attachments/assets/aaa371a9-c98a-48b9-9b12-b994a64bd4fa" />

</details>

## Changelog
:cl:
fix: fixed the tauric weight multiplier not being rounded
/:cl:
