### PR TITLE
Lets you spawn in as a custom Icewalker

### DIFF
--- a/modular_skyrat/modules/primitive_catgirls/code/spawner.dm
+++ b/modular_skyrat/modules/primitive_catgirls/code/spawner.dm
@@ -22,6 +22,9 @@
 	quirks_enabled = TRUE
 	random_appearance = FALSE
 	loadout_enabled = FALSE
+	//GS13 EDIT
+	allow_custom_character = GHOSTROLE_TAKE_PREFS_SPECIES //bring icewalker in line with ashwalker. custom icewalkers!
+	//GS13 EDIT END
 	uses = 9
 	deletes_on_zero_uses_left = FALSE
 


### PR DESCRIPTION

## About The Pull Request

Takes one line from ashwalkers (code\modules\mob_spawn\ghost_roles\mining_roles.dm, line 238) that sets the allow_custom_character var and adds it to the icewalkers. Seems to be the standard for allowing custom appearance, at least as far as ashwalkers go.
## Why It's Good For The Game

Currently, you can't spawn in as a custom icewalker. The Hearthkin are a selectable species in character creation. However, you always spawn in with randomized appearance as an icewalker. As Hearthkin cannot speak Common, they can't play any role other than Stowaway. This doesn't make much sense as the species is for or at least from the Icewalker role.
## Proof Of Testing
<details>
<summary>Screenshots/Videos</summary>
<img width="395" height="663" alt="image" src="https://github.com/user-attachments/assets/21edd580-2e25-40bf-90a6-8bfd86f32433" />

</details>

## Changelog
:cl:
add: Icewalker role now lets you spawn in as a custom character.
/:cl:
