### PR TITLE
fix: wrap WATTS_PER_BFI macro in parentheses to fix operator precedence

### DIFF
--- a/modular_gs/code/machinery/adipoelectric_transformer.dm
+++ b/modular_gs/code/machinery/adipoelectric_transformer.dm
@@ -4,7 +4,7 @@ GLOBAL_LIST_EMPTY(adipoelectric_transformer)
 #define MEGA_WATT *1000000
 /// the base amount of power needed to bwomph someone up by one BFI.
 /// Also decides the point at which the scaling slows down.
-#define WATTS_PER_BFI	500 KILO_WATT
+#define WATTS_PER_BFI	(500 KILO_WATT)
 
 /obj/machinery/power/adipoelectric_transformer
 	name = "adipoelectric transformer"


### PR DESCRIPTION
About:
Fixed missing parentheses in WATTS_PER_BFI macro to ensure correct operator precedence during division.

Why it's good:
Prevents unintended power scaling and ensures the machine works as originally intended.

Changelog:
:cl: aliden1z
fix: Fixed a math bug in the Adipoelectric Transformer's power scaling.
/:cl: