### PR TITLE
Helplessness refactor

### DIFF
--- a/modular_gs/code/controllers/configuration/configuration.dm
+++ b/modular_gs/code/controllers/configuration/configuration.dm
@@ -1,5 +1,6 @@
-/// runs the functions responsible for configuring some GS13 content
+/// runs the functions responsible for configuring some GS13 content.
 /// PLEASE attempt to only hold function calls here, and perform
 /// any logic/calculations inside your own procs
 /datum/controller/configuration/proc/gs13_configuration()
 	populate_event_perks()
+	populate_helplessness_mechanics()

--- a/modular_gs/code/datums/_helplessness.dm
+++ b/modular_gs/code/datums/_helplessness.dm
@@ -39,11 +39,20 @@ ahhhh~! It's all documented too~ 🥵
 	SHOULD_NOT_OVERRIDE(TRUE)
 
 	if (sanity_checks(fatty) == FALSE)
+		disable_helplessness(fatty)
 		return FALSE
 	
 	var/trigger_weight = get_trigger_weight(fatty)
 
 	var/effective_fatness = fatty.calculate_effective_fatness()
+
+	if (trigger_weight <= 0)
+		disable_helplessness(fatty)
+		return FALSE
+	
+	if (effective_fatness < trigger_weight)
+		disable_helplessness(fatty)
+		return FALSE
 
 	return apply_helplessness(fatty, trigger_weight, effective_fatness)
 
@@ -94,33 +103,38 @@ ahhhh~! It's all documented too~ 🥵
 	return trigger_weight
 
 /**
- * Compares trigger weight and (effective) fatness, and applies/removes helplessness traits accordingly.
+ * Applies helplessness trait(s). Basically, if you're here, means that you can apply the trait
  * Override this for custom behaviour, adding/deleting multiple trait under one helplessness pref etc.
  * 
- * Returns FALSE when the trait is not applied/active.
+ * Returns FALSE if the trait was not applied.
  * 
- * Returns TRUE when the trais is applied/active.
+ * Returns TRUE if the trais was applied.
  */
 /datum/helplessness/proc/apply_helplessness(mob/living/carbon/human/fatty, trigger_weight, fatness)
 	PROTECTED_PROC(TRUE)
 
-	if (trigger_weight <= 0)
-		if (HAS_TRAIT_FROM(fatty, helplessness_trait, HELPLESSNESS_TRAIT))
-			REMOVE_TRAIT(fatty, helplessness_trait, HELPLESSNESS_TRAIT)
-		
-		return FALSE
-
 	if (!HAS_TRAIT_FROM(fatty, helplessness_trait, HELPLESSNESS_TRAIT))
-		if (fatness >= trigger_weight)
-			to_chat(fatty, span_warning(gain_message))
-			ADD_TRAIT(fatty, helplessness_trait, HELPLESSNESS_TRAIT)
-			return TRUE
+		to_chat(fatty, span_warning(gain_message))
+		ADD_TRAIT(fatty, helplessness_trait, HELPLESSNESS_TRAIT)
+		return TRUE
 		
-		return FALSE
-		
-	else if (fatness < trigger_weight)
+	return FALSE
+
+/**
+ * Disables the helplessness mechanics. Basically, if you're here, you know you have to remove the trait
+ * Override this if you need to do some cleanup of your own
+ * 
+ * returns TRUE if the trait was present and was removed
+ * 
+ * returns FALSE if the trait wasn't removed (because it wasn't there to begin with. You can use this behavior to speed up
+ * removing multiple traits since AFAIK a single if (bool) check is faster than looking up if you have trait X or not)
+ */
+/datum/helplessness/proc/disable_helplessness(mob/living/carbon/human/fatty)
+	PROTECTED_PROC(TRUE)
+
+	if (HAS_TRAIT_FROM(fatty, helplessness_trait, HELPLESSNESS_TRAIT))
 		to_chat(fatty, span_notice(lose_message))
 		REMOVE_TRAIT(fatty, helplessness_trait, HELPLESSNESS_TRAIT)
-		return FALSE
-	
-	return TRUE
+		return TRUE
+
+	return FALSE

--- a/modular_gs/code/datums/_helplessness.dm
+++ b/modular_gs/code/datums/_helplessness.dm
@@ -1,3 +1,4 @@
+GLOBAL_LIST_EMPTY_TYPED(helplessness_mechanics, /datum/helplessness)
 /**
  * A datum responsible for handling helplessness mechanics.
  * Check out [modular_gs/code/datums/helplessness/helplessness.dm] for examples on how to extend this
@@ -8,6 +9,7 @@
  * Or just tell me what a good little coder boy I am that'll make me happy too.
  */
 /datum/helplessness
+	abstract_type = /datum/helplessness
 	/// the helplessness mechanic this triggers
 	var/helplessness_trait = 0
 	/// default BFI value at which this triggers - essentially the value used by quirks
@@ -138,3 +140,8 @@ ahhhh~! It's all documented too~ 🥵
 		return TRUE
 
 	return FALSE
+
+/proc/populate_helplessness_mechanics()
+	for (var/helplessness_mechanic in subtypesof(/datum/helplessness))
+		var/datum/helplessness/helplessness_datum = new helplessness_mechanic
+		GLOB.helplessness_mechanics.Add(helplessness_datum)

--- a/modular_gs/code/datums/helplessness/helplessness.dm
+++ b/modular_gs/code/datums/helplessness/helplessness.dm
@@ -21,28 +21,15 @@
 	return trigger_weight
 
 /datum/helplessness/clumsy
-	helplessness_trait = TRAIT_CLUMSY
+	helplessness_trait = TRAIT_CHUNKYFINGERS
 	default_trigger_weight = FATNESS_LEVEL_BARELYMOBILE
 	override_quirk = TRAIT_HELPLESS_CLUMSY
 	preference = /datum/preference/numeric/helplessness/clumsy
 	gain_message = "Your newfound weight has made it hard to manipulate objects."
 	lose_message = "You feel like you have lost enough weight to recover your dexterity."
 
-/datum/helplessness/clumsy/apply_helplessness(mob/living/carbon/human/fatty, trigger_weight, fatness)
-	. = ..()
-	var/should_be_active = .
-
-	if (should_be_active)
-		if (!HAS_TRAIT_FROM(fatty, TRAIT_CHUNKYFINGERS, HELPLESSNESS_TRAIT))
-			ADD_TRAIT(fatty, TRAIT_CHUNKYFINGERS, HELPLESSNESS_TRAIT)
-	else
-		if (HAS_TRAIT_FROM(fatty, TRAIT_CHUNKYFINGERS, HELPLESSNESS_TRAIT))
-			REMOVE_TRAIT(fatty, TRAIT_CHUNKYFINGERS, HELPLESSNESS_TRAIT)
-	
-	return should_be_active
-
 /datum/helplessness/nearsighted
-	helplessness_trait = 0	// nearsighted isn't a trait the same way others are
+	helplessness_trait = null	// nearsighted isn't a trait the same way others are
 	default_trigger_weight = FATNESS_LEVEL_BLOB
 	override_quirk = TRAIT_HELPLESS_BIG_CHEEKS
 	preference = /datum/preference/numeric/helplessness/nearsighted
@@ -50,34 +37,31 @@
 	lose_message = "You are thin enough to see your environment better."
 
 /datum/helplessness/nearsighted/apply_helplessness(mob/living/carbon/human/fatty, trigger_weight, fatness)
-	if (trigger_weight <= 0)
-		fatty.remove_fov_trait(TRAIT_VERY_LOW_FOV, FOV_270_DEGREES)
-		fatty.remove_fov_trait(TRAIT_LOW_FOV, FOV_180_DEGREES)
-		REMOVE_TRAIT(fatty, TRAIT_VERY_LOW_FOV, HELPLESSNESS_TRAIT)
-		REMOVE_TRAIT(fatty, TRAIT_LOW_FOV, HELPLESSNESS_TRAIT)
-		return FALSE
-
 	if(fatness >= 2 * trigger_weight)
 		if(!HAS_TRAIT(fatty, TRAIT_VERY_LOW_FOV))
 			to_chat(fatty, span_warning(gain_message))
 			ADD_TRAIT(fatty, TRAIT_VERY_LOW_FOV, HELPLESSNESS_TRAIT)
 			REMOVE_TRAIT(fatty, TRAIT_LOW_FOV, HELPLESSNESS_TRAIT)
 			fatty.add_fov_trait(TRAIT_LOW_FOV, FOV_270_DEGREES)
-		return TRUE
+			return TRUE
 
-	if(fatness >= trigger_weight)
-		if(!HAS_TRAIT(fatty, TRAIT_LOW_FOV))
-			to_chat(fatty, span_warning(gain_message))
-			ADD_TRAIT(fatty, TRAIT_LOW_FOV, HELPLESSNESS_TRAIT)
-			REMOVE_TRAIT(fatty, TRAIT_VERY_LOW_FOV, HELPLESSNESS_TRAIT)
-			fatty.add_fov_trait(TRAIT_LOW_FOV, FOV_180_DEGREES)
-		return TRUE
+		return FALSE
 
+	if(!HAS_TRAIT(fatty, TRAIT_LOW_FOV))
+		to_chat(fatty, span_warning(gain_message))
+		ADD_TRAIT(fatty, TRAIT_LOW_FOV, HELPLESSNESS_TRAIT)
+		REMOVE_TRAIT(fatty, TRAIT_VERY_LOW_FOV, HELPLESSNESS_TRAIT)
+		fatty.add_fov_trait(TRAIT_LOW_FOV, FOV_180_DEGREES)
+		return TRUE
+	
+	return FALSE
+
+/datum/helplessness/nearsighted/disable_helplessness(mob/living/carbon/human/fatty)
 	fatty.remove_fov_trait(TRAIT_VERY_LOW_FOV, FOV_270_DEGREES)
 	fatty.remove_fov_trait(TRAIT_LOW_FOV, FOV_180_DEGREES)
 	REMOVE_TRAIT(fatty, TRAIT_VERY_LOW_FOV, HELPLESSNESS_TRAIT)
 	REMOVE_TRAIT(fatty, TRAIT_LOW_FOV, HELPLESSNESS_TRAIT)
-	return FALSE
+	return TRUE
 
 /datum/helplessness/hidden_face
 	helplessness_trait = TRAIT_DISFIGURED
@@ -105,18 +89,19 @@
 
 /datum/helplessness/immobile_arms/apply_helplessness(mob/living/carbon/human/fatty, trigger_weight, fatness)
 	. = ..()
-	var/should_be_active = .
+	var/activated = .
 
-	if (should_be_active)
-		if (!HAS_TRAIT_FROM(fatty, TRAIT_PARALYSIS_R_ARM, HELPLESSNESS_TRAIT))
-			ADD_TRAIT(fatty, TRAIT_PARALYSIS_R_ARM, HELPLESSNESS_TRAIT)
-			fatty.update_body_parts()
-	else
-		if (HAS_TRAIT_FROM(fatty, TRAIT_PARALYSIS_R_ARM, HELPLESSNESS_TRAIT))
-			REMOVE_TRAIT(fatty, TRAIT_PARALYSIS_R_ARM, HELPLESSNESS_TRAIT)
-			fatty.update_body_parts()
-	
-	return should_be_active
+	if (activated)
+		ADD_TRAIT(fatty, TRAIT_PARALYSIS_R_ARM, HELPLESSNESS_TRAIT)
+		fatty.update_body_parts()
+
+/datum/helplessness/immobile_arms/disable_helplessness(mob/living/carbon/human/fatty)
+	. = ..()
+	var/disabled_helplessness = .
+
+	if (disabled_helplessness)
+		REMOVE_TRAIT(fatty, TRAIT_PARALYSIS_R_ARM, HELPLESSNESS_TRAIT)
+		fatty.update_body_parts()
 
 /datum/helplessness/jumpsuit_bursting
 	helplessness_trait = TRAIT_NO_JUMPSUIT
@@ -127,19 +112,12 @@
 	lose_message = "You feel thin enough to put on jumpsuits now."
 
 /datum/helplessness/jumpsuit_bursting/apply_helplessness(mob/living/carbon/human/fatty, trigger_weight, fatness)
-	. = ..()
-	// the super function to this returns true if the helplessness mechanic is active, and false otherwise
-	var/should_be_active = .
-
-	if (!should_be_active)
-		return should_be_active
+	..()
 	
 	var/obj/item/clothing/under/jumpsuit = fatty.w_uniform
 	if(istype(jumpsuit))
 		to_chat(fatty, span_warning("[jumpsuit] can no longer contain your weight!"))
 		fatty.dropItemToGround(jumpsuit)
-	
-	return should_be_active
 
 /datum/helplessness/misc_clothing_bursting
 	helplessness_trait = TRAIT_NO_MISC
@@ -151,11 +129,6 @@
 
 /datum/helplessness/misc_clothing_bursting/apply_helplessness(mob/living/carbon/human/fatty, trigger_weight, fatness)
 	. = ..()
-	// the super function to this returns true if the helplessness mechanic is active, and false otherwise
-	var/should_be_active = .
-
-	if (!should_be_active)
-		return should_be_active
 	
 	var/obj/item/clothing/suit/worn_suit = fatty.wear_suit
 	if(istype(worn_suit) && !istype(worn_suit, /obj/item/clothing/suit/mod))
@@ -171,8 +144,6 @@
 	if(istype(worn_shoes) && !istype(worn_shoes, /obj/item/clothing/shoes/mod))
 		to_chat(fatty, span_warning("[worn_shoes] can no longer contain your weight!"))
 		fatty.dropItemToGround(worn_shoes)
-	
-	return should_be_active
 
 /datum/helplessness/belt_bursting	// my beloved
 	helplessness_trait = TRAIT_NO_BELT
@@ -184,10 +155,6 @@
 
 /datum/helplessness/belt_bursting/apply_helplessness(mob/living/carbon/human/fatty, trigger_weight, fatness)
 	. = ..()
-	var/should_be_active = .
-
-	if (!should_be_active)
-		return should_be_active
 
 	var/obj/item/bluespace_belt/primitive/PBS_belt = fatty.belt
 	if(istype(PBS_belt) && fatness > trigger_weight)
@@ -201,8 +168,6 @@
 			span_warning("With a loud ripping sound, [fatty]'s [belt] snaps open!"),
 			span_warning("With a loud ripping sound, your [belt] snaps open!"))
 		fatty.dropItemToGround(belt)
-	
-	return should_be_active
 
 /datum/helplessness/back_clothing
 	helplessness_trait = TRAIT_NO_BACKPACK
@@ -214,17 +179,11 @@
 
 /datum/helplessness/back_clothing/apply_helplessness(mob/living/carbon/human/fatty, trigger_weight, fatness)
 	. = ..()
-	var/should_be_active = .
-
-	if (!should_be_active)
-		return should_be_active
 
 	var/obj/item/back_item = fatty.back
 	if(istype(back_item) && !istype(back_item, /obj/item/mod))
 		to_chat(fatty, span_warning("Your weight makes it impossible for you to carry [back_item]."))
 		fatty.dropItemToGround(back_item)
-	
-	return should_be_active
 
 /datum/helplessness/no_buckle
 	helplessness_trait = TRAIT_NO_BUCKLE
@@ -244,18 +203,11 @@
 
 /datum/helplessness/no_neck/apply_helplessness(mob/living/carbon/human/fatty, trigger_weight, fatness)
 	. = ..()
-	// the super function to this returns true if the helplessness mechanic is active, and false otherwise
-	var/should_be_active = .
-
-	if (!should_be_active)
-		return should_be_active
 	
 	var/obj/item/clothing/neck/neckwear = fatty.wear_neck
 	if(istype(neckwear))
 		to_chat(fatty, span_warning("[neckwear] can no longer fit around your neck!"))
 		fatty.dropItemToGround(neckwear)
-	
-	return should_be_active
 
 #define MAX_PRESSURE_DEBUFF 0.5
 /*

--- a/modular_gs/code/modules/mob/living/species.dm
+++ b/modular_gs/code/modules/mob/living/species.dm
@@ -53,10 +53,8 @@
 		update_body_size(H, weight_stage + 1)
 
 /mob/living/carbon/human/proc/handle_helplessness()
-	for (var/helplessness_mechanic in subtypesof(/datum/helplessness))
-		var/datum/helplessness/helplessness_datum = new helplessness_mechanic
-		helplessness_datum.handle_helplessness(src)
-		qdel(helplessness_datum)
+	for (var/datum/helplessness/helplessness_mechanic as anything in GLOB.helplessness_mechanics)
+		helplessness_mechanic.handle_helplessness(src)
 
 /datum/movespeed_modifier/fatness
 	id = "fat"


### PR DESCRIPTION
## About The Pull Request

Refactors helplessness and fixes bugs.

The `apply_helplessness` proc is now serving purely as a way to activate the helplessness mechanic. Basically, if it fired, it means all the conditions to apply the trait have been met. A new proc to disable the helplessness mechanic, aptly named `disable_helplessness` serves the opposite purpose, firing any time the requirements of the helplessness mechanics haven't been met and it must be disabled. `handle_helplessness` was adjusted to reflect those changes; It will now call `disable_helplessness` if the player fails the `sanity_checks`, the `trigger_weight` is lower or equal to zero (the helplessness mechanic pref is disabled) or the `effective_fatness` is lower than the trigger weight. Otherwise, it calls and returns `apply_helplessness`.

`apply_helplessness` and `disable_helplessness` still retain their boolean returns. These can be used for mechanics which apply more than one trait or have custom behavior aside from applying a trait. Simply check if the `.` returns `TRUE` or `FALSE` and it will tell you whether you should activate/disable your custom mechanics or not; this is likely much faster than running `HAS_TRAIT` or any other checks again.

## Why It's Good For The Game

Makes it easier to work with and fixes bugs

closes #432 

## Changelog

:cl: Swan
add: thick fingers from weight helplessness mechanic no longer gives the clumsy trait
fix: fixes the MOD mobility assist module breaking helplessness mechanics triggering
code: refactored helplessness code. Again.
/:cl: