### PR TITLE
Adds in the Silverscale tongue, which allows you to turn into a statue.

### DIFF
--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -28,7 +28,8 @@
 	AddElement(art_type, impressiveness)
 	AddElement(/datum/element/beauty, impressiveness * 75)
 	AddElement(/datum/element/simple_rotation)
-///	AddComponent(/datum/component/marionette)
+    // GS13 EDIT adds silverscale tongue
+    //	AddComponent(/datum/component/marionette)
 	if(should_marionette)/// GS13 EDIT
 		AddComponent(/datum/component/marionette) /// GS13 EDIT
 

--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -28,6 +28,7 @@
 	AddElement(art_type, impressiveness)
 	AddElement(/datum/element/beauty, impressiveness * 75)
 	AddElement(/datum/element/simple_rotation)
+///	AddComponent(/datum/component/marionette)
 	if(should_marionette)/// GS13 EDIT
 		AddComponent(/datum/component/marionette) /// GS13 EDIT
 

--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -22,13 +22,17 @@
 	var/art_type = /datum/element/art
 	/// Set to true to prevent it from being carved out of a block
 	var/uncarveable = FALSE
+	/// GS13 EDIT START
+	var/should_marionette = TRUE
+	/// GS13 EDIT END
 
 /obj/structure/statue/Initialize(mapload)
 	. = ..()
 	AddElement(art_type, impressiveness)
 	AddElement(/datum/element/beauty, impressiveness * 75)
 	AddElement(/datum/element/simple_rotation)
-	AddComponent(/datum/component/marionette)
+	if(should_marionette)/// GS13 EDIT
+		AddComponent(/datum/component/marionette) /// GS13 EDIT
 
 /obj/structure/statue/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
@@ -629,3 +633,7 @@ Moving interrupts
 		. += content_ma
 
 #undef SCULPT_SOUND_INCREMENT
+
+/// GS13 EDIT
+/obj/structure/statue/custom/silverscale
+	should_marionette = FALSE

--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -22,9 +22,6 @@
 	var/art_type = /datum/element/art
 	/// Set to true to prevent it from being carved out of a block
 	var/uncarveable = FALSE
-	/// GS13 EDIT START
-	var/should_marionette = TRUE
-	/// GS13 EDIT END
 
 /obj/structure/statue/Initialize(mapload)
 	. = ..()
@@ -633,7 +630,3 @@ Moving interrupts
 		. += content_ma
 
 #undef SCULPT_SOUND_INCREMENT
-
-/// GS13 EDIT
-/obj/structure/statue/custom/silverscale
-	should_marionette = FALSE

--- a/code/modules/art/statues.dm
+++ b/code/modules/art/statues.dm
@@ -28,8 +28,8 @@
 	AddElement(art_type, impressiveness)
 	AddElement(/datum/element/beauty, impressiveness * 75)
 	AddElement(/datum/element/simple_rotation)
-    // GS13 EDIT adds silverscale tongue
-    //	AddComponent(/datum/component/marionette)
+	// GS13 EDIT adds silverscale tongue
+	//	AddComponent(/datum/component/marionette)
 	if(should_marionette)/// GS13 EDIT
 		AddComponent(/datum/component/marionette) /// GS13 EDIT
 

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -254,7 +254,8 @@
 		return FALSE
 
 	if(isnull(statue))
-///			if(feedback)
+		// GS13 EDIT START
+		// if(feedback)
 ///			owner.balloon_alert(owner, "you can't seem to statue-ize!")
 ///		return FALSE // permanently bricked
 		init_statue() // GS13 EDIT
@@ -288,7 +289,8 @@
 	if(is_statue)
 		statue.visible_message(span_danger("[statue] becomes animated!"))
 		owner.forceMove(get_turf(statue))
-///				statue.moveToNullspace()
+			// GS13 EDIT START
+			// statue.moveToNullspace()
 		qdel(statue) //GS13 EDIT
 		UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
 
@@ -324,9 +326,10 @@
 
 	to_chat(carbon_owner, span_userdanger("Your existence as a living creature snaps as your statue form crumbles!"))
 	carbon_owner.forceMove(get_turf(statue))
-///		carbon_owner.dust(just_ash = TRUE, drop_items = TRUE)
+	// GS13 EDIT START
+	// carbon_owner.dust(just_ash = TRUE, drop_items = TRUE)
 ///	carbon_owner.investigate_log("has been dusted from having their Silverscale Statue deconstructed / destroyed.", INVESTIGATE_DEATHS)
-	carbon_owner.adjust_brute_loss(300) // GS13 EDIT START
+	carbon_owner.adjust_brute_loss(300)
 	// carbon_owner.dust(just_ash = TRUE, drop_items = TRUE)
 	carbon_owner.investigate_log("has been killed from having their Silverscale Statue deconstructed / destroyed.", INVESTIGATE_DEATHS)
 	/// GS13 EDIT END

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -227,7 +227,7 @@
 
 	/// The statue we turn into.
 	/// We only ever make one (in New) and simply move it into nullspace or back.
-	var/obj/structure/statue/custom/silverscale/statue /// GS13 EDIT
+	var/obj/structure/statue/custom/statue
 
 /datum/action/cooldown/turn_to_statue/New(Target)
 	. = ..()
@@ -255,7 +255,6 @@
 
 	if(isnull(statue))
 		init_statue() // GS13 EDIT
-
 	if(owner.stat != CONSCIOUS)
 		if(feedback)
 			owner.balloon_alert(owner, "you're too weak!")
@@ -321,10 +320,10 @@
 
 	to_chat(carbon_owner, span_userdanger("Your existence as a living creature snaps as your statue form crumbles!"))
 	carbon_owner.forceMove(get_turf(statue))
-	carbon_owner.adjust_brute_loss(300) // GS13 EDIT
+	carbon_owner.adjust_brute_loss(300) // GS13 EDIT START
 	// carbon_owner.dust(just_ash = TRUE, drop_items = TRUE)
 	carbon_owner.investigate_log("has been killed from having their Silverscale Statue deconstructed / destroyed.", INVESTIGATE_DEATHS)
-
+	/// GS13 EDIT END
 	clean_up_statue() // unregister signal before we can do further side effects.
 
 /// Statue was qdeleted outright, do nothing but clear refs.

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -254,6 +254,9 @@
 		return FALSE
 
 	if(isnull(statue))
+///			if(feedback)
+///			owner.balloon_alert(owner, "you can't seem to statue-ize!")
+///		return FALSE // permanently bricked
 		init_statue() // GS13 EDIT
 	if(owner.stat != CONSCIOUS)
 		if(feedback)
@@ -285,6 +288,7 @@
 	if(is_statue)
 		statue.visible_message(span_danger("[statue] becomes animated!"))
 		owner.forceMove(get_turf(statue))
+///				statue.moveToNullspace()
 		qdel(statue) //GS13 EDIT
 		UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
 
@@ -320,6 +324,8 @@
 
 	to_chat(carbon_owner, span_userdanger("Your existence as a living creature snaps as your statue form crumbles!"))
 	carbon_owner.forceMove(get_turf(statue))
+///		carbon_owner.dust(just_ash = TRUE, drop_items = TRUE)
+///	carbon_owner.investigate_log("has been dusted from having their Silverscale Statue deconstructed / destroyed.", INVESTIGATE_DEATHS)
 	carbon_owner.adjust_brute_loss(300) // GS13 EDIT START
 	// carbon_owner.dust(just_ash = TRUE, drop_items = TRUE)
 	carbon_owner.investigate_log("has been killed from having their Silverscale Statue deconstructed / destroyed.", INVESTIGATE_DEATHS)

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -227,7 +227,7 @@
 
 	/// The statue we turn into.
 	/// We only ever make one (in New) and simply move it into nullspace or back.
-	var/obj/structure/statue/custom/statue
+	var/obj/structure/statue/custom/silverscale/statue /// GS13 EDIT
 
 /datum/action/cooldown/turn_to_statue/New(Target)
 	. = ..()
@@ -254,9 +254,8 @@
 		return FALSE
 
 	if(isnull(statue))
-		if(feedback)
-			owner.balloon_alert(owner, "you can't seem to statue-ize!")
-		return FALSE // permanently bricked
+		init_statue() // GS13 EDIT
+
 	if(owner.stat != CONSCIOUS)
 		if(feedback)
 			owner.balloon_alert(owner, "you're too weak!")
@@ -287,7 +286,7 @@
 	if(is_statue)
 		statue.visible_message(span_danger("[statue] becomes animated!"))
 		owner.forceMove(get_turf(statue))
-		statue.moveToNullspace()
+		qdel(statue) //GS13 EDIT
 		UnregisterSignal(owner, COMSIG_MOVABLE_MOVED)
 
 	else
@@ -322,8 +321,9 @@
 
 	to_chat(carbon_owner, span_userdanger("Your existence as a living creature snaps as your statue form crumbles!"))
 	carbon_owner.forceMove(get_turf(statue))
-	carbon_owner.dust(just_ash = TRUE, drop_items = TRUE)
-	carbon_owner.investigate_log("has been dusted from having their Silverscale Statue deconstructed / destroyed.", INVESTIGATE_DEATHS)
+	carbon_owner.adjust_brute_loss(300) // GS13 EDIT
+	// carbon_owner.dust(just_ash = TRUE, drop_items = TRUE)
+	carbon_owner.investigate_log("has been killed from having their Silverscale Statue deconstructed / destroyed.", INVESTIGATE_DEATHS)
 
 	clean_up_statue() // unregister signal before we can do further side effects.
 

--- a/modular_gs/code/modules/art/statues.dm
+++ b/modular_gs/code/modules/art/statues.dm
@@ -1,0 +1,5 @@
+/obj/structure/statue
+  var/should_marionette = TRUE
+
+/obj/structure/statue/custom/silverscale
+	should_marionette = FALSE

--- a/modular_gs/code/modules/customization/modules/client/augment/organs.dm
+++ b/modular_gs/code/modules/customization/modules/client/augment/organs.dm
@@ -1,0 +1,4 @@
+/datum/augment_item/organ/tongue/tongue/lizard/silver
+	name = "Silverscale tongue"
+	path = /obj/item/organ/tongue/lizard/silver
+	cost = 2

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7129,6 +7129,7 @@
 #include "modular_gs\code\modules\clothing\under\jobs\modular_items.dm"
 #include "modular_gs\code\modules\clothing\under\jobs\modular_clothing\button_up.dm"
 #include "modular_gs\code\modules\clothing\under\jobs\modular_clothing\dual_tone.dm"
+#include "modular_gs\code\modules\customization\modules\client\augment\organs.dm"
 #include "modular_gs\code\modules\customization\modules\mob\living\carbon\human\species\hemophage\hemophage_status_effects.dm"
 #include "modular_gs\code\modules\customization\species\proteans\organs\protean_stomach.dm"
 #include "modular_gs\code\modules\event_perk_redeemer\event_perk.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7101,6 +7101,7 @@
 #include "modular_gs\code\mechanics\xwg.dm"
 #include "modular_gs\code\mechanics\transformation\new_tf_item.dm"
 #include "modular_gs\code\mobs\chocoslime.dm"
+#include "modular_gs\code\modules\art\statues.dm"
 #include "modular_gs\code\modules\atmospherics\gasmixtures\gas_types.dm"
 #include "modular_gs\code\modules\atmospherics\gasmixtures\reaction_factors.dm"
 #include "modular_gs\code\modules\atmospherics\gasmixtures\reactions.dm"


### PR DESCRIPTION
## About The Pull Request

Tweaks and adds the silverscale tongue to the augments+ menu. Previously it only belonged to a specific branch of pirates and was rather useless to them.

## Why It's Good For The Game

Seeing as (hopefully) the people can be trusted with silly RP stuff here, this makes it so gargoyles can be real and true. Its mostly just RP flavor after all. It doesn't protect you from spacing.

## Proof Of Testing


https://github.com/user-attachments/assets/219d2da0-0d3e-4ba2-8e27-cd508c27c5d4

<img width="680" height="355" alt="Screenshot 2026-05-21 115230" src="https://github.com/user-attachments/assets/8063c28c-8420-4036-8555-7694326abd17" />


Code compiled and ran properly, turning in and out of a statue works, statue destruction works properly and does not dust you like it used to.

## Changelog

:cl:
add: Added the Silverscale tongue to the augments+ menu and tweaked how it works. Gargoyles rejoice!
/:cl: