### PR TITLE
Sound Prefs and Minor Balance Change

### DIFF
--- a/modular_gs/code/modules/client/preferences/noise_preferences.dm
+++ b/modular_gs/code/modules/client/preferences/noise_preferences.dm
@@ -13,3 +13,7 @@
 	savefile_key = "sound_digestive"
 	savefile_identifier = PREFERENCE_PLAYER
 
+/datum/preference/numeric/volume/sound_bursting
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "sound_bursting"
+	savefile_identifier = PREFERENCE_PLAYER

--- a/modular_gs/code/modules/mob/living/bursting.dm
+++ b/modular_gs/code/modules/mob/living/bursting.dm
@@ -209,10 +209,11 @@
 		if (client?.prefs?.read_preference(/datum/preference/toggle/glutton_enable_sounds)) //Check if the player wants sounds
 			//Compare the two capcity percentages to each other and play sounds if they're higher than a percentage of the other
 			if ((bursting_capacity_fullness > bursting_capacity_fatness * BURSTING_SOUND_RATIO)) //Do fullness sounds
-				playsound(src.loc, pick(BURSTING_GURGLE_SOUNDS), BURSTING_SOUND_VOLUME, 1, 1, 1.2, ignore_walls = FALSE)
+				playsound(src.loc, pick(BURSTING_GURGLE_SOUNDS), BURSTING_SOUND_VOLUME, 1, 1, 1.2, ignore_walls = FALSE, volume_preference = /datum/preference/numeric/volume/sound_bursting)
+
 
 			if ((bursting_capacity_fatness > bursting_capacity_fullness * BURSTING_SOUND_RATIO)) //Do fatness sounds
-				playsound(src.loc, pick(BURSTING_FAT_SLOSH_SOUNDS), BURSTING_SOUND_VOLUME, 1, 1, 1.2, ignore_walls = FALSE)
+				playsound(src.loc, pick(BURSTING_FAT_SLOSH_SOUNDS), BURSTING_SOUND_VOLUME, 1, 1, 1.2, ignore_walls = FALSE, volume_preference = /datum/preference/numeric/volume/sound_bursting)
 
 	if (!client?.prefs?.read_preference(/datum/preference/toggle/glutton_see_bursting))
 		return FALSE
@@ -270,7 +271,7 @@
 		abs(BURSTING_ANIMATE_SCALE_X * cos(lying_angle) + BURSTING_ANIMATE_SCALE_Y * sin(lying_angle)),
 		abs(BURSTING_ANIMATE_SCALE_Y * cos(lying_angle) + BURSTING_ANIMATE_SCALE_X * sin(lying_angle))
 	)
-	playsound(src.loc, BURSTING_CRESCENDO, BURSTING_SOUND_VOLUME, 1, 1, 1.2, ignore_walls = FALSE)
+	playsound(src.loc, BURSTING_CRESCENDO, BURSTING_SOUND_VOLUME, 1, 1, 1.2, ignore_walls = FALSE, volume_preference = /datum/preference/numeric/volume/sound_bursting)
 	animate(src, time = BURSTING_ANIMATE_TIME SECONDS, transform = transform * scale_transform, easing = SINE_EASING, flags = ANIMATION_PARALLEL)
 	Stun(BURSTING_ANIMATE_TIME SECONDS, TRUE)
 
@@ -282,13 +283,13 @@
 			span_warning("[src] makes a loud creak as the swelling stops on the verge of bursting, they seem to be holding together for now... (People with bursting prefs disabled are in view!)"),
 			span_warning("You make a loud creak as the swelling momentarily stops as you struggle to hold together... (Someone with bursting prefs disabled is in view!)")
 		)
-		playsound(src.loc, BURSTING_CRESCENDO_DELAY, BURSTING_SOUND_VOLUME, 1, 1, 1.2, ignore_walls = FALSE)
+		playsound(src.loc, BURSTING_CRESCENDO_DELAY, BURSTING_SOUND_VOLUME, 1, 1, 1.2, ignore_walls = FALSE, volume_preference = /datum/preference/numeric/volume/sound_bursting)
 		addtimer(CALLBACK(src, PROC_REF(burst_glutton)), 8.4 SECONDS) //Delay for the duration of the sound
 		return
 
 	var/bursting_pref = get_bursting_pref()
 	if (bursting_pref != BURSTING_PREF_DISABLED) //Do one last check to make sure the player actually wanted it
-		playsound(src.loc, BURSTING_BURST, BURSTING_SOUND_VOLUME, 1, 1, 1.2, ignore_walls = FALSE)
+		playsound(src.loc, BURSTING_BURST, BURSTING_SOUND_VOLUME, 1, 1, 1.2, ignore_walls = FALSE, volume_preference = /datum/preference/numeric/volume/sound_bursting)
 		visible_message(span_warning("[src]'s body lets out a final creak before bursting!"), span_warning("You feel your body let out a creak as the pressure becomes too much before bursting!"))
 
 		//Get the fatness pref again incase it was changed since they burst and use it to determine the reduction so that the player doesn't repeatedly burst
@@ -334,7 +335,7 @@
 
 				//Injure modes
 				if (bursting_pref == BURSTING_PREF_INJURE || bursting_pref == BURSTING_PREF_CRIT)
-					var/bursting_chest_damage = bursting_pref == BURSTING_PREF_INJURE ? 40 : 100 ///40 damage if in injure, 110 if in crit mode
+					var/bursting_chest_damage = bursting_pref == BURSTING_PREF_INJURE ? 40 : 110 ///40 damage if in injure, 110 if in crit mode
 					var/bursting_limb_damage = bursting_pref == BURSTING_PREF_INJURE ? 5 : 10 ///How much damage to do to the limbs if fatness bursting
 					var/bursting_stomach_damage = bursting_pref == BURSTING_PREF_INJURE ? 30 : 100 ///How much damage to do to the stomach when fullness bursting
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/gs13/content.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/gs13/content.tsx
@@ -108,3 +108,10 @@ export const sound_digestive: Feature<number> = {
   description: 'Volume of eating, drinking, and gurgling.',
   component: FeatureSliderInput,
 };
+
+export const sound_bursting: Feature<number> = {
+  name: 'Bursting sounds volume',
+  category: 'SOUND',
+  description: 'Volume of the sounds associated with bursting.',
+  component: FeatureSliderInput,
+};


### PR DESCRIPTION

## About The Pull Request

Adds a volume control pref for fatness/fullness bursting, ten damage increase to crit bursting to make out-healing it slightly less likely

## Why It's Good For The Game

Adds a volume preference for all the bursting related sounds so people are not driven crazy by all the people being sloshy all the time.

## Proof Of Testing

I tested it with Koko's help to also ensure that using the volume controls actually changed the volume of the sounds
<details>
<summary>Screenshots/Videos</summary>
<img width="797" height="138" alt="image" src="https://github.com/user-attachments/assets/6bee2f65-c6fd-4218-abb4-a2897ce2385d" />
<img width="1089" height="795" alt="image" src="https://github.com/user-attachments/assets/08e013ce-dfc3-49fe-b1d9-c04fd4add7df" />


See? perfectly silent with it disabled :)
<img width="1355" height="831" alt="image" src="https://github.com/user-attachments/assets/7cdab01e-b89f-4ac4-adae-38f186fd9c73" />
</details>

## Changelog

:cl: Grarem
add: Prefed bursting related sounds
balance: small increase in damage done while crit bursting
/:cl:
