### PR TITLE
Fixes the character creator tabs being very wide

### DIFF
--- a/modular_gs/code/modules/client/preferences/genitals.dm
+++ b/modular_gs/code/modules/client/preferences/genitals.dm
@@ -2,6 +2,7 @@
 
 //the butt itself
 /datum/preference/choiced/genital/butt
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_key = "feature_butt"
 	relevant_mutant_bodypart = ORGAN_SLOT_BUTT
 	default_accessory_type = /datum/sprite_accessory/genital/butt/none
@@ -60,6 +61,7 @@
 
 //tummy
 /datum/preference/choiced/genital/belly
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
 	savefile_key = "feature_belly"
 	relevant_mutant_bodypart = ORGAN_SLOT_BELLY
 	default_accessory_type = /datum/sprite_accessory/genital/belly/none

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferences/MainPage.tsx
@@ -907,6 +907,10 @@ export function MainPage(props: MainPageProps) {
         {/* BUBBER EDIT CHANGE BEGIN: Swappable pref menus */}
         <Stack.Item grow basis={0} ml="4px">
           <Stack vertical fill>
+            {/* GS13 EDIT */}
+            <Stack vertical>
+            <Stack.Item>
+            {/* GS13 END EDIT */}
             <Stack>
               <Stack.Item grow={2}>
                 <PageButton
@@ -954,6 +958,10 @@ export function MainPage(props: MainPageProps) {
                 </PageButton>
               </Stack.Item>
               {/* GS13 EDIT */}
+              </Stack>
+              </Stack.Item>
+              <Stack.Item>
+                <Stack>
               <Stack.Item grow={2}>
                 <PageButton
                   currentPage={currentPrefPage}
@@ -980,6 +988,8 @@ export function MainPage(props: MainPageProps) {
               <Stack.Item>{blueberry_contents}</Stack.Item>
               <Stack.Item>{glutton_bursting_contents}</Stack.Item>
               {/* GS13 END EDIT */}
+            </Stack>
+            </Stack.Item>
             </Stack>
           </Stack>
         </Stack.Item>


### PR DESCRIPTION
## About The Pull Request

The character creator no longer needs to be pulled to the side to see all the bars

## Why It's Good For The Game

Closes #434

## Changelog

:cl: Swan
fix: the character creator tabs are no longer extending past the window borders
/:cl: