### PR TITLE
New Ghost Cafe Condo - Feeder Den

### DIFF
--- a/modular_gs/code/modules/condos/_maps/feeder_den.dmm
+++ b/modular_gs/code/modules/condos/_maps/feeder_den.dmm
@@ -1,5 +1,841 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1
+	},
+/obj/structure/railing{
+	color = "#36373a"
+	},
+/obj/structure/fake_stairs/directional/south{
+	icon_state = "stairs-old";
+	icon = 'icons/turf/floors.dmi';
+	color = "#555555";
+	dir = 8;
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"am" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
 "aq" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/machinery/vending/gato{
+	free = 1
+	},
+/obj/structure/sign/poster/official/waddle/directional/north,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"aw" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"aG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -9
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -16
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/misc/condo)
+"aQ" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/decorative{
+	icon = 'modular_skyrat/modules/advanced_shuttles/icons/computer.dmi';
+	icon_state = "computer_left";
+	density = 1;
+	anchored = 1
+	},
+/obj/structure/decorative{
+	icon_state = "wallmount";
+	pixel_y = 31;
+	icon = 'icons/obj/science/circuits.dmi';
+	dir = 8;
+	anchored = 1;
+	name = "wallmount"
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"aZ" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/fluff/paper/stack{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"ba" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"bh" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/hay,
+/area/misc/condo)
+"bo" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/knife/butcher{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 11;
+	pixel_y = -9
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"bq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cell 4"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"bx" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy"
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/structure/sign/flag/syndicate/directional/south,
+/obj/effect/turf_decal/trimline/dark_red,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"by" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
+	dir = 8
+	},
+/area/misc/condo)
+"bF" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Vault"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"bI" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"bT" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"bU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"bV" = (
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/shuttle/exploration,
+/area/misc/condo)
+"ce" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/paper/fluff/ruins/feeder_den/report4{
+	pixel_x = 9;
+	pixel_y = 14
+	},
+/obj/item/pen/red{
+	pixel_x = 2;
+	pixel_y = 14
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/lighter{
+	pixel_x = 3;
+	pixel_y = -12
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"cn" = (
+/obj/machinery/vending/mealdor{
+	free = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/iron/shuttle/exploration/doubleside,
+/area/misc/condo)
+"cp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"ct" = (
+/obj/structure/rack/shelf,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/mineral/titanium/fifty{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"cx" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side,
+/area/misc/condo)
+"cz" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"cC" = (
+/obj/structure/closet/secure_closet/freezer/kitchen/all_access,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"cM" = (
+/obj/machinery/computer/security/telescreen/entertainment,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/misc/condo)
+"cT" = (
+/obj/machinery/computer/security/telescreen/entertainment,
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
+/area/misc/condo)
+"cW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"dp" = (
+/obj/item/reagent_containers/cup/bottle/succubus_milk{
+	pixel_x = -11;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/sign/poster/contraband/donut_corp/directional/east,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"dG" = (
+/obj/item/trash/boritos{
+	pixel_x = 12;
+	pixel_y = -13
+	},
+/obj/item/trash/candy/twink_bar{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/trash/energybar{
+	pixel_x = 17;
+	pixel_y = 17
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"dI" = (
+/obj/structure/bed/maint{
+	pixel_x = 13;
+	pixel_y = -1
+	},
+/obj/item/restraints/handcuffs{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"dR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"dW" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/box,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"ea" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/side{
+	dir = 1
+	},
+/area/misc/condo)
+"ec" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/misc/condo)
+"ef" = (
+/obj/machinery/griddle/frontier_tabletop,
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"en" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"eo" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"eq" = (
+/obj/structure/chair/sofa/corp,
+/obj/item/reagent_containers/cup/bowl,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"eG" = (
+/obj/structure/safe,
+/obj/item/toy/plush/rouny,
+/obj/item/stack/arcadeticket{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/clothing/head/hair_tie/plastic_beads,
+/turf/open/floor/circuit/red,
+/area/misc/condo)
+"eQ" = (
+/obj/structure/flora/rock/pile,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"fb" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Storage"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"fn" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/misc/condo)
+"fv" = (
+/obj/machinery/iv_drip/feeding_tube,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"fy" = (
+/obj/machinery/vending/clothing,
+/turf/open/floor/iron/shuttle/exploration/textured_flat,
+/area/misc/condo)
+"fF" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"fL" = (
+/obj/machinery/plantgenes{
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/shuttle/exploration,
+/area/misc/condo)
+"fN" = (
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/structure/chair/beanbag/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"fO" = (
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/machinery/shower/directional/west,
+/obj/structure/decorative{
+	icon_state = "drain";
+	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
+	base_icon_state = "drain";
+	dir = 8;
+	name = "drain";
+	anchored = 1;
+	pixel_x = -1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"fP" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/iv_drip/feeding_tube,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"fR" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 8;
+	use_holiday_colors = 0
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"gh" = (
+/obj/structure/reagent_dispensers/servingdish{
+	name = "nutrislop dish";
+	desc = "Syndicate's finest, sloppest."
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/hay,
+/area/misc/condo)
+"gk" = (
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"gn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"go" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/shuttle/exploration/side,
+/area/misc/condo)
+"gq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"gy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/misc/condo)
+"gC" = (
+/obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/shuttle/exploration,
+/area/misc/condo)
+"gI" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"gQ" = (
+/obj/structure/rack/shelf{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/item/melee/baton/security/cattleprod/loaded{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/melee/baton/security/cattleprod/loaded{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"gR" = (
+/obj/item/grenade/chem_grenade/fatmix{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/holosign_creator/hardlight_wheelchair{
+	pixel_x = 14;
+	pixel_y = 9
+	},
+/obj/item/holosign_creator/hardlight_wheelchair{
+	pixel_x = 14;
+	pixel_y = 2
+	},
+/obj/item/holosign_creator/hardlight_wheelchair{
+	pixel_x = 14;
+	pixel_y = -5
+	},
+/obj/machinery/vending/wallmed/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"gU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/side{
+	dir = 1
+	},
+/area/misc/condo)
+"gY" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/noticeboard/directional/north,
+/obj/item/photo/old{
+	pixel_x = 5;
+	pixel_y = 25;
+	name = "photo of marines";
+	desc = "Remember your roots."
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"hb" = (
+/obj/structure/cable,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"hg" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/vending/dinnerware{
+	free = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"hp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"hw" = (
+/obj/structure/table/optable,
+/obj/item/storage/backpack/duffelbag/syndie/surgery{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"hz" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/structure/railing{
+	color = "#36373a"
+	},
+/obj/item/training_toolbox{
+	name = "ambiguous toolbox";
+	icon_state = "coroner";
+	desc = "Don't cum on the servers.";
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/obj/item/screwdriver{
+	pixel_x = -1;
+	pixel_y = 13
+	},
+/obj/structure/decorative{
+	icon_state = "wallmount";
+	pixel_y = 31;
+	icon = 'icons/obj/science/circuits.dmi';
+	dir = 8;
+	anchored = 1;
+	name = "wallmount"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/shuttle/exploration/equipmentrail2,
+/area/misc/condo)
+"hB" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/eat/directional/west,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"hF" = (
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/misc/condo)
+"hJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"hK" = (
+/obj/item/trash/fleet_ration,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"hT" = (
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"ii" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side{
+	dir = 1
+	},
+/area/misc/condo)
+"io" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
@@ -10,17 +846,437 @@
 	},
 /turf/open/floor/wood/tile,
 /area/misc/condo)
-"as" = (
-/obj/structure/disposalpipe/segment{
+"iq" = (
+/obj/item/reagent_containers/cup/bottle/succubus_milk{
+	pixel_x = -5;
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/cup/bottle/succubus_milk{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/hay,
+/area/misc/condo)
+"iv" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"iw" = (
+/obj/machinery/vending/hydronutrients,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/shuttle/exploration,
+/area/misc/condo)
+"iL" = (
+/obj/structure/scale,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"iM" = (
+/obj/item/trash/tray,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"iO" = (
+/obj/structure/falsewall/plastitanium,
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating,
+/area/misc/condo)
+"jj" = (
+/obj/machinery/light/directional/north,
+/obj/structure/sign/poster/contraband/loosen/directional/north,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"jm" = (
+/obj/structure/cable,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"jn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"ju" = (
+/obj/machinery/iv_drip/gs13/plumbing_milker,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/misc/condo)
+"jK" = (
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/trimline/dark_red,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"jO" = (
+/obj/structure/gs13_fluff/brokenhose{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/misc/condo)
+"jQ" = (
+/obj/structure/sign/warning/radiation{
+	pixel_y = -31
+	},
+/obj/structure/cable,
+/obj/item/shell/server{
+	name = "skyrat Sector server";
+	desc = "On the side you see a small LCD saying 'CONGRATULATIONS ITS BEEN 0 DAYS SINCE A UNIT TEST FAILED! A NEW RECORD!'";
+	anchored = 1;
+	pixel_x = -11;
+	pixel_y = 1
+	},
+/obj/structure/fluff/bus/passable/seat{
+	icon = 'icons/obj/machines/telecomms.dmi';
+	icon_state = "blackbox_b";
+	density = 1;
+	pixel_y = 0;
+	uses_integrity = 0;
+	name = "Copium Mining Server";
+	desc = "400TB of various tears and crashouts from maintainers and contributors alike. We're not sure how you got this many, but it's probably best not to ask.";
+	pixel_x = 12
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/misc/condo)
+"jR" = (
+/obj/structure/sink/directional/west,
+/obj/structure/mirror/directional/east,
+/obj/effect/turf_decal/siding/wideplating/light/end{
 	dir = 4
+	},
+/obj/structure/decorative{
+	icon_state = "drain";
+	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
+	base_icon_state = "drain";
+	dir = 8;
+	name = "drain";
+	anchored = 1;
+	pixel_x = -16;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"jU" = (
+/obj/item/skillchip/brainwashing{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/item/skillchip/brainwashing{
+	pixel_x = -11;
+	pixel_y = 5
+	},
+/obj/item/skillchip/brainwashing{
+	pixel_x = 4;
+	pixel_y = 17
+	},
+/obj/item/disk/surgery/brainwashing{
+	pixel_x = -11;
+	pixel_y = -10
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"kA" = (
+/obj/item/trash/candy{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 1;
+	use_holiday_colors = 0
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"kE" = (
+/obj/machinery/iv_drip/feeding_tube,
+/turf/open/floor/iron/shuttle/exploration/textured_flat,
+/area/misc/condo)
+"kH" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/trimline/dark,
+/obj/effect/turf_decal/trimline/dark,
+/obj/effect/turf_decal/trimline/dark,
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"kW" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/chonk/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"kZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = 31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system."
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"ld" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"ll" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 1;
+	name = "O2 To Pure"
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/lipoifium,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"lr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Tech Tests"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"lv" = (
+/obj/machinery/power/apc{
+	name = "Base Power Controller";
+	pixel_x = -28
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"lB" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/medkit/brute{
+	pixel_x = 0;
+	pixel_y = -2
+	},
+/obj/item/storage/medkit/fire{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"lK" = (
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"lL" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/open/floor/iron/small,
+/area/misc/condo)
+"lM" = (
+/obj/structure/chair/sofa/corp/right,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"lN" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner,
+/area/misc/condo)
+"lZ" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"mb" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 1;
+	use_holiday_colors = 0
+	},
+/obj/item/plate_shard{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"mz" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"mC" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"mG" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/shuttle/exploration,
+/area/misc/condo)
+"mI" = (
+/obj/structure/cable,
+/obj/item/storage/toolbox/syndicate{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/item/organ/cyberimp/chest/nutriment/turbo{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/organ/cyberimp/chest/nutriment/turbo{
+	pixel_x = 10;
+	pixel_y = -13
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"mL" = (
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"mO" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"mR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"mS" = (
+/obj/item/trash/fatoray_scrap1,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"mT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/dark,
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
 /turf/open/floor/mineral/plastitanium,
 /area/misc/condo)
-"aD" = (
+"nn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
@@ -40,19 +1296,417 @@
 	},
 /turf/open/floor/iron/shuttle/exploration/doubleside,
 /area/misc/condo)
-"aR" = (
-/obj/structure/curtain,
-/turf/open/floor/iron/freezer,
-/area/misc/condo)
-"aS" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+"nC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister/galbanium,
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/side{
+	dir = 1
+	},
 /area/misc/condo)
-"aW" = (
+"nD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/iron/shuttle/exploration/doubleside,
+/area/misc/condo)
+"nE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cell 4"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"nM" = (
+/obj/structure/cable,
+/obj/item/shell/bot{
+	name = "skyrat Sector server";
+	desc = "There's a sticky note on the side. It says 'Todo: Fix Serenity Station Crash Issues'";
+	anchored = 1;
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/misc/condo)
+"nS" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"nY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"od" = (
+/obj/effect/turf_decal/siding/wideplating/light/end{
+	dir = 1
+	},
+/obj/structure/toilet,
+/obj/machinery/light/small/directional/east{
+	pixel_x = 0;
+	pixel_y = -11
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"oe" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/box/beakers/bluespace,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"of" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/effect/spawner/random/bedsheet/any,
+/obj/effect/spawner/random/bedsheet/any,
+/obj/effect/spawner/random/bedsheet/any,
+/obj/effect/spawner/random/bedsheet/any,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"oo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"oz" = (
+/obj/structure/bed/maint,
+/obj/item/clothing/neck/human_petcollar/calorite{
+	pixel_x = 3;
+	pixel_y = -6
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"oB" = (
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 8
+	},
+/area/misc/condo)
+"oD" = (
+/obj/machinery/door/poddoor/shutters/window/preopen,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"oE" = (
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"oG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/shuttle/exploration/side{
+	dir = 1
+	},
+/area/misc/condo)
+"oO" = (
+/obj/structure/flora/bush/grassy,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"oW" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"oX" = (
+/obj/item/reagent_containers/cup/bottle/succubus_milk{
+	pixel_x = 7;
+	pixel_y = 14
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/directional/west,
+/obj/structure/sign/poster/contraband/moffuchis_pizza/directional/west,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"oY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"oZ" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = 31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system."
+	},
+/obj/item/trash/tray,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"pa" = (
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1
+	},
+/obj/structure/decorative/fluff{
+	icon = 'icons/turf/floors.dmi';
+	base_icon_state = "stairs-old";
+	icon_state = "stairs-m";
+	anchored = 1;
+	pixel_y = 0;
+	name = "staircase";
+	desc = "A small step for the humanity, and so is for you.";
+	dir = 4;
+	color = "#474747"
+	},
+/obj/structure/fake_stairs/directional/south{
+	icon_state = "stairs-old";
+	icon = 'icons/turf/floors.dmi';
+	color = "#555555";
+	dir = 8;
+	pixel_y = 1
+	},
+/obj/structure/fake_stairs/directional/south{
+	icon_state = "stairs-old";
+	icon = 'icons/turf/floors.dmi';
+	color = "#555555";
+	dir = 8;
+	pixel_y = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"ph" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"pA" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/item/plate{
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/obj/item/plate{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/plate{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/plate{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"pR" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = -4
+	},
+/obj/item/storage/fancy/donut_box,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"pS" = (
+/obj/item/food/burger/greaseburger{
+	pixel_x = 1;
+	pixel_y = 14
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"qm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"qx" = (
+/obj/structure/gs13_fluff/brokenhose/scraps3{
+	pixel_x = -2;
+	pixel_y = -11
+	},
+/obj/structure/reagent_dispensers/cooking_oil/cream,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/misc/condo)
+"qy" = (
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"qG" = (
+/obj/machinery/shower/directional/west,
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/structure/decorative{
+	icon_state = "drain";
+	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
+	base_icon_state = "drain";
+	dir = 8;
+	name = "drain";
+	anchored = 1;
+	pixel_x = -1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"qH" = (
+/obj/structure/rack/shelf,
+/obj/item/stack/sheet/cardboard{
+	amount = 3
+	},
+/obj/item/stack/sheet/cardboard{
+	amount = 3
+	},
+/obj/item/stack/sheet/cardboard{
+	amount = 3
+	},
+/obj/item/stack/sheet/cardboard{
+	amount = 3
+	},
+/obj/item/stack/rods/twentyfive,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/structure/cable,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"qO" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/hatch{
+	name = "Entrance & Engineering"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"qT" = (
+/obj/machinery/vending/dorms,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"qV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"rc" = (
 /obj/item/reagent_containers/cup/soda_cans/dr_gibb{
 	pixel_x = -1;
 	pixel_y = 4
@@ -71,157 +1725,10 @@
 	pixel_x = 0;
 	pixel_y = 0
 	},
+/obj/structure/sign/poster/contraband/eat/directional/west,
 /turf/open/floor/wood/tile,
 /area/misc/condo)
-"aX" = (
-/obj/vehicle/ridden/wheelchair,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"bd" = (
-/obj/structure/scale,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"bt" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/syndicate,
-/obj/item/multitool,
-/obj/item/clothing/head/utility/welding,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"bD" = (
-/obj/structure/window/fulltile,
-/obj/structure/hedge,
-/turf/open/floor/plating,
-/area/misc/condo)
-"bJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/circuit/red,
-/area/misc/condo)
-"bK" = (
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
-/obj/machinery/shower/directional/west,
-/obj/structure/decorative{
-	icon_state = "drain";
-	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
-	base_icon_state = "drain";
-	dir = 8;
-	name = "drain";
-	anchored = 1;
-	pixel_x = -1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding{
-	dir = 4
-	},
-/turf/open/floor/iron/white/diagonal,
-/area/misc/condo)
-"bR" = (
-/obj/structure/rack/shelf,
-/obj/item/storage/box/beakers/bluespace,
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"bX" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/storage/box/handcuffs{
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"ca" = (
-/obj/machinery/computer/security/telescreen/entertainment,
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
-/area/misc/condo)
-"cb" = (
-/turf/closed/wall/r_wall/plastitanium/syndicate,
-/area/misc/condo)
-"cd" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"ce" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"co" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/siding/wideplating/light/end{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/west{
-	pixel_x = 0;
-	pixel_y = 13
-	},
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"cp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
-	dir = 1
-	},
-/area/misc/condo)
-"cs" = (
-/obj/structure/safe,
-/obj/item/toy/plush/rouny,
-/obj/item/stack/arcadeticket{
-	pixel_x = 4;
-	pixel_y = 1
-	},
-/obj/item/clothing/head/hair_tie/plastic_beads,
-/turf/open/floor/circuit/red,
-/area/misc/condo)
-"ct" = (
+"re" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -257,22 +1764,13 @@
 	dir = 1
 	},
 /area/misc/condo)
-"cy" = (
-/obj/structure/disposalpipe/segment{
+"rh" = (
+/obj/effect/turf_decal/siding{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark/corner,
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"cC" = (
-/obj/machinery/shower/directional/east,
+/obj/effect/turf_decal/siding/wideplating/light/end,
+/obj/structure/sink/directional/north,
+/obj/structure/mirror/directional/south,
 /obj/structure/decorative{
 	icon_state = "drain";
 	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
@@ -280,502 +1778,12 @@
 	dir = 8;
 	name = "drain";
 	anchored = 1;
-	pixel_x = -1
-	},
-/obj/effect/turf_decal/siding/wideplating/light/end{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating/light/end{
-	dir = 4
+	pixel_x = 0;
+	pixel_y = 11
 	},
 /turf/open/floor/iron/white/small,
 /area/misc/condo)
-"cM" = (
-/obj/item/trash/candy,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"cY" = (
-/obj/machinery/light/floor{
-	brightness = 7.5;
-	pixel_x = 16;
-	pixel_y = -16
-	},
-/obj/effect/turf_decal/trimline/dark/corner,
-/obj/effect/turf_decal/trimline/dark/corner,
-/turf/open/floor/mineral/plastitanium/red,
-/area/misc/condo)
-"da" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 9
-	},
-/obj/structure/chair/sofa/bench/left{
-	dir = 4
-	},
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/obj/structure/marker_beacon/cerulean,
-/turf/open/floor/iron/small,
-/area/misc/condo)
-"dd" = (
-/obj/machinery/smartfridge/food,
-/obj/item/food/taco,
-/obj/item/food/nigiri_sushi,
-/obj/item/food/spaghetti/pastatomato,
-/obj/item/reagent_containers/cup/glass/bottle/small{
-	pixel_x = -11;
-	pixel_y = 19
-	},
-/obj/item/reagent_containers/cup/glass/bottle/small{
-	pixel_x = -2;
-	pixel_y = 19
-	},
-/obj/item/reagent_containers/cup/glass/bottle{
-	pixel_x = 8;
-	pixel_y = 22
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"dj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"dr" = (
-/obj/machinery/power/port_gen/pacman/super,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"dv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side{
-	dir = 1
-	},
-/area/misc/condo)
-"dx" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"dK" = (
-/obj/machinery/chem_dispenser/mutagensaltpeter,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/shuttle/exploration,
-/area/misc/condo)
-"dL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/misc/condo)
-"dP" = (
-/obj/effect/turf_decal/siding/dark/corner,
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"ep" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"ez" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"eN" = (
-/obj/item/screwdriver,
-/turf/open/misc/asteroid/airless,
-/area/misc/condo)
-"eT" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"eX" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"ff" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/stripes/red/corner,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"fk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"fn" = (
-/obj/structure/chair/sofa/corp,
-/obj/item/gun/energy/laser/alter_ray/noloss{
-	pixel_x = -5;
-	pixel_y = -2
-	},
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"fq" = (
-/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
-/area/misc/condo)
-"fr" = (
-/obj/structure/closet/wardrobe/mixed,
-/turf/open/floor/iron/shuttle/exploration/textured_flat,
-/area/misc/condo)
-"fB" = (
-/obj/machinery/cryopod/quiet{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"fO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/misc/condo)
-"gj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/misc/condo)
-"gx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Cell 4"
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"gy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/misc/condo)
-"gz" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/paper/fluff/ruins/feeder_den/report4{
-	pixel_x = 9;
-	pixel_y = 14
-	},
-/obj/item/pen/red{
-	pixel_x = 2;
-	pixel_y = 14
-	},
-/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
-	pixel_x = -7;
-	pixel_y = -9
-	},
-/obj/item/lighter{
-	pixel_x = 3;
-	pixel_y = -12
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/obj/item/flashlight/lamp{
-	pixel_x = -6;
-	pixel_y = 9
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"gE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"gZ" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/obj/structure/rack/shelf,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/effect/turf_decal/siding/dark/corner,
-/obj/item/melee/baton/telescopic{
-	pixel_x = -3;
-	pixel_y = 10
-	},
-/obj/item/melee/baton/telescopic{
-	pixel_x = 11;
-	pixel_y = 10
-	},
-/obj/item/melee/baton/telescopic{
-	pixel_x = 4;
-	pixel_y = 10
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"hd" = (
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/mineral/plastitanium/red,
-/area/misc/condo)
-"hr" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/chair/beanbag/red{
-	dir = 8
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"ht" = (
-/obj/vehicle/ridden/wheelchair,
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"hC" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/reagentgrinder,
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -9;
-	pixel_y = -1
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"hD" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/item/trash/pistachios,
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"hH" = (
-/obj/structure/cable,
-/obj/structure/railing/corner/end{
-	dir = 4;
-	color = "#36373a";
-	pixel_x = 0;
-	pixel_y = 28
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	color = "#59595a";
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"hJ" = (
-/obj/structure/chair/sofa/corp/corner,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"hQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"hW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/siding/dark,
-/obj/machinery/light/floor{
-	pixel_x = 0;
-	pixel_y = 16
-	},
-/obj/effect/turf_decal/trimline/dark{
-	pixel_x = 0;
-	pixel_y = 16
-	},
-/obj/effect/turf_decal/trimline/dark{
-	pixel_x = 0;
-	pixel_y = 16
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/misc/condo)
-"ib" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 9
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/misc/condo)
-"ie" = (
-/obj/structure/rack/shelf,
-/obj/item/vending_refill/mealdor,
-/obj/item/vending_refill/mealdor,
-/obj/item/vending_refill/mealdor,
-/obj/item/vending_refill/mealdor,
-/obj/item/vending_refill/cola,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"if" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"is" = (
-/obj/machinery/vending/mealdor{
-	free = 1
-	},
-/obj/effect/turf_decal/siding/dark/corner,
-/turf/open/floor/iron/shuttle/exploration/doubleside,
-/area/misc/condo)
-"iw" = (
-/obj/machinery/vending/fatty_items,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"iF" = (
-/obj/machinery/vending/hydroseeds{
-	slogan_delay = 700
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/shuttle/exploration,
-/area/misc/condo)
-"iM" = (
+"rk" = (
 /obj/machinery/atmospherics/components/tank/air/layer4{
 	dir = 1
 	},
@@ -786,7 +1794,366 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/pod/dark,
 /area/misc/condo)
-"iN" = (
+"ro" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Quarters"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"rp" = (
+/turf/open/space/basic,
+/area/misc/condo)
+"rs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/iron/shuttle/exploration/side,
+/area/misc/condo)
+"rt" = (
+/obj/item/clothing/mask/ballgag{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/food/cake/chocolate{
+	pixel_x = 4;
+	pixel_y = 19
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/directional/east,
+/obj/structure/sign/poster/contraband/jumbo_bar/directional/east,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"rv" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/light/floor{
+	pixel_x = 0;
+	pixel_y = 16
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"rB" = (
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
+/area/misc/condo)
+"rR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing/corner/end{
+	dir = 8;
+	color = "#36373a";
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#59595a";
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"rU" = (
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy"
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/porta_turret/syndicate/fattening,
+/turf/open/floor/plating,
+/area/misc/condo)
+"rV" = (
+/obj/structure/table,
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = 31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system."
+	},
+/obj/item/plate{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/item/plate{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/item/plate{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/plate{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/plate{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/plate{
+	pixel_x = 2;
+	pixel_y = 9
+	},
+/obj/item/plate{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/obj/item/plate{
+	pixel_x = 1;
+	pixel_y = 14
+	},
+/obj/item/plate{
+	pixel_x = 1;
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"sg" = (
+/obj/item/food/meat/bacon{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"sl" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"sp" = (
+/obj/machinery/door/poddoor/shutters/window/preopen,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"sy" = (
+/obj/machinery/iv_drip/gs13/plumbing_feeder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/misc/condo)
+"sN" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"sT" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/misc/condo)
+"sW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/side{
+	dir = 1
+	},
+/area/misc/condo)
+"td" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -9
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -16
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -23
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"tk" = (
+/obj/item/trash/can{
+	pixel_x = 11;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 2
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"tn" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"tI" = (
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"tO" = (
+/obj/item/trash/tray,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"uc" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"ug" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/galbanium,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"uA" = (
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"uT" = (
+/obj/structure/window/fulltile,
+/obj/structure/hedge,
+/turf/open/floor/plating,
+/area/misc/condo)
+"uY" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/vending/dinnerware{
+	free = 1
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"vb" = (
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"vu" = (
+/obj/structure/scale,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/structure/sign/poster/contraband/donut_corp/directional/east,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"vw" = (
+/obj/structure/reagent_dispensers/cooking_oil,
+/obj/structure/sign/poster/official/calorite/directional/north,
+/turf/open/floor/hay,
+/area/misc/condo)
+"vA" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/box/hecu_rations{
 	pixel_x = -7;
@@ -812,31 +2179,123 @@
 	},
 /turf/open/floor/iron/white/small,
 /area/misc/condo)
-"iO" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/microwave/frontier_printed,
-/turf/open/floor/iron/dark/textured_large,
+"vH" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium/red,
 /area/misc/condo)
-"iX" = (
-/obj/machinery/door/airlock/hatch,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"vL" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"vQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/hatch{
+	name = "Storage"
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/misc/condo)
-"ja" = (
-/obj/machinery/power/apc{
-	name = "Base Power Controller";
-	pixel_x = -28
+"wd" = (
+/obj/structure/rack/shelf,
+/obj/item/vending_refill/mealdor,
+/obj/item/vending_refill/mealdor,
+/obj/item/vending_refill/mealdor,
+/obj/item/vending_refill/mealdor,
+/obj/item/vending_refill/cola,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"wh" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/box,
+/obj/machinery/light/small/dim/directional/west,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"ww" = (
+/obj/structure/ore_box,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"wz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"wH" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Junk Shed"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"wR" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"wS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
 	},
 /turf/open/floor/pod/dark,
 /area/misc/condo)
-"jj" = (
-/obj/item/trash/candy{
-	pixel_x = 10;
-	pixel_y = -3
+"xc" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
 	},
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/dresser,
+/obj/item/sign/flag/syndicate{
+	pixel_x = 1;
+	pixel_y = 13
+	},
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"xj" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
@@ -851,84 +2310,176 @@
 	},
 /turf/open/floor/wood/tile,
 /area/misc/condo)
-"jk" = (
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
-/obj/effect/turf_decal/siding/wideplating/light{
-	dir = 5
+"xl" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
 	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/reagent_dispensers/cooking_oil/cream/open,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"xp" = (
+/obj/structure/flora/bush/jungle/a/style_3,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"xJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/wideplating/light/corner{
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding{
-	dir = 4
+/turf/open/floor/iron/shuttle/exploration/side{
+	dir = 1
 	},
-/turf/open/floor/iron/white/diagonal,
 /area/misc/condo)
-"jr" = (
-/obj/structure/filingcabinet,
-/obj/item/folder/syndicate/mining,
-/obj/item/folder/syndicate/red,
+"xM" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
+	dir = 8
+	},
+/area/misc/condo)
+"xP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/misc/condo)
+"xQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
 /turf/open/floor/circuit/red,
 /area/misc/condo)
-"jv" = (
-/obj/machinery/vending/boozeomat/syndicate,
-/obj/machinery/light/directional/south,
+"xW" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/food/meat/slab/pig,
+/obj/item/food/meat/slab/pig,
+/obj/item/food/meat/slab/pig,
+/obj/item/food/meat/slab/mouse,
+/obj/item/food/meat/slab/mouse,
+/obj/item/food/meat/slab/mouse,
+/obj/item/food/meat/slab/mouse,
+/obj/item/food/meat/slab/meatproduct,
+/obj/item/food/meat/slab/meatproduct,
+/obj/item/food/meat/slab/meatproduct,
+/obj/item/food/meat/slab/meatproduct,
+/obj/item/food/meat/slab/meatproduct,
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/meat/steak,
+/obj/item/food/meat/steak,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
+/area/misc/condo)
+"yh" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"yi" = (
+/obj/item/trash/boritos,
+/obj/machinery/light/directional/north,
+/obj/structure/sign/poster/official/waddle/directional/north,
 /turf/open/floor/carpet/red,
 /area/misc/condo)
-"jA" = (
-/obj/structure/rack/shelf,
-/obj/item/stack/sheet/glass/fifty{
-	pixel_x = 2;
-	pixel_y = 2
+"yq" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
 	},
-/obj/item/stack/sheet/mineral/titanium/fifty{
-	pixel_x = 0;
-	pixel_y = 4
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
 	},
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy"
 	},
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"jB" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo"
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
 	},
+/obj/effect/turf_decal/trimline/dark_red,
 /turf/open/floor/iron/dark/textured_large,
 /area/misc/condo)
-"jG" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/storage/fancy/large_donut_box{
-	pixel_x = 0;
-	pixel_y = 2
+"ys" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
 	},
-/obj/item/storage/fancy/large_donut_box{
-	pixel_x = 0;
-	pixel_y = 8
-	},
-/obj/item/storage/fancy/large_donut_box{
-	pixel_x = 0;
-	pixel_y = 14
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/turf/open/floor/mineral/plastitanium,
 /area/misc/condo)
-"jM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/hatch,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
+"yx" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/box/beakers,
+/obj/item/reagent_containers/cup/soda_cans/air,
+/obj/item/reagent_containers/cup/soda_cans/beer,
+/obj/item/reagent_containers/cup/soda_cans/beer/rice,
+/obj/item/reagent_containers/cup/soda_cans/blood_tea,
+/obj/item/reagent_containers/cup/soda_cans/canned_laughter,
+/obj/item/reagent_containers/cup/soda_cans/cola,
+/obj/item/reagent_containers/cup/soda_cans/dr_gibb,
+/obj/item/reagent_containers/cup/soda_cans/fizzwiz,
+/obj/item/reagent_containers/cup/soda_cans/grey_bull,
+/obj/item/reagent_containers/cup/soda_cans/lemon_lime,
+/obj/item/reagent_containers/cup/soda_cans/melon_soda,
+/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
+/obj/item/reagent_containers/cup/soda_cans/pwr_game,
+/obj/item/reagent_containers/cup/soda_cans/shamblers,
+/turf/open/floor/iron/dark/textured_large,
 /area/misc/condo)
-"jP" = (
+"yJ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -945,123 +2496,28 @@
 	},
 /turf/open/floor/pod/dark,
 /area/misc/condo)
-"jY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
+"yN" = (
+/obj/machinery/recharger,
+/obj/item/implanter{
+	pixel_x = 9;
+	pixel_y = 15
 	},
-/obj/machinery/implantchair/brainwash,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/misc/condo)
-"kc" = (
-/obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/shuttle/exploration,
-/area/misc/condo)
-"ke" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 5
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/machinery/vending/gato{
-	free = 1
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"kl" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding{
-	dir = 8
-	},
-/turf/open/floor/iron/white/diagonal,
-/area/misc/condo)
-"kt" = (
-/obj/effect/turf_decal/siding/dark/corner,
-/obj/machinery/computer/operating{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/misc/condo)
-"kx" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
-/obj/effect/turf_decal/siding/wideplating/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding{
-	dir = 8
-	},
-/obj/item/kitchen/spoon/soup_ladle{
-	name = "sauna ladle";
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/turf/open/floor/iron/white/diagonal,
-/area/misc/condo)
-"kK" = (
-/obj/machinery/light/floor,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"kN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/misc/condo)
-"kR" = (
-/obj/item/food/meat/bacon{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 5
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
+/obj/item/implanter{
+	pixel_x = 9;
+	pixel_y = 11
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
-/turf/open/floor/wood/tile,
+/turf/open/floor/iron/dark/textured_large,
 /area/misc/condo)
-"kU" = (
-/turf/open/floor/iron/shuttle/exploration/uside{
-	dir = 8
+"yP" = (
+/obj/machinery/vending/hotdog{
+	onstation = 0;
+	onstation_override = 1;
+	all_products_free = 1
 	},
+/turf/open/floor/iron/shuttle/exploration/textured_flat,
 /area/misc/condo)
-"lf" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	color = "#5d341f";
-	dir = 2
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"lq" = (
-/obj/structure/reagent_dispensers/servingdish{
-	name = "nutrislop dish";
-	desc = "Syndicate's finest, sloppest."
-	},
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/hay,
-/area/misc/condo)
-"lE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
+"yR" = (
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 1
 	},
@@ -1073,250 +2529,43 @@
 	pixel_x = 16;
 	pixel_y = -16
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"lG" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"lP" = (
-/obj/structure/flora/bush/jungle/a/style_3,
-/turf/open/misc/asteroid/airless,
-/area/misc/condo)
-"lW" = (
-/obj/structure/flora/bush/jungle,
-/turf/open/misc/asteroid/airless,
-/area/misc/condo)
-"mb" = (
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/misc/condo)
-"me" = (
-/obj/structure/cable,
-/obj/machinery/light/floor,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"mf" = (
-/obj/item/construction/plumbing{
-	pixel_x = 3;
-	pixel_y = -18
-	},
-/obj/item/circuitboard/machine/power/adipoelectric_generator{
-	pixel_x = 11;
-	pixel_y = 0
-	},
-/obj/item/circuitboard/machine/adipoelectric_transformer{
-	pixel_x = -5;
-	pixel_y = 9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/small/dim/directional/west,
-/turf/open/floor/plating,
-/area/misc/condo)
-"mj" = (
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"mk" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/misc/condo)
-"mB" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/book/manual/chef_recipes{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"mD" = (
-/obj/item/plate/large,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"mF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/pod/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/misc/condo)
-"mR" = (
-/obj/structure/bed/maint,
-/obj/item/clothing/neck/human_petcollar/calorite{
-	pixel_x = 3;
-	pixel_y = -6
+"yY" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
 	},
-/turf/open/floor/carpet/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
+	dir = 1
+	},
 /area/misc/condo)
-"mU" = (
+"yZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/misc/condo)
-"na" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"nd" = (
-/obj/item/paper/fluff/ruins/feeder_den/hidden,
-/turf/open/floor/plating,
-/area/misc/condo)
-"nf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"ni" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Cell 1"
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"nk" = (
-/obj/item/trash/tray,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"no" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/knife/butcher{
-	pixel_x = 2;
-	pixel_y = 1
-	},
-/obj/item/kitchen/rollingpin{
-	pixel_x = 11;
-	pixel_y = -9
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"nt" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"ny" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 2
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"nP" = (
-/turf/open/space/basic,
-/area/misc/condo)
-"nW" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 2
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"oj" = (
-/obj/structure/flora/rock/pile,
-/turf/open/misc/asteroid/airless,
-/area/misc/condo)
-"om" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/misc/condo)
-"op" = (
-/obj/item/storage/box/drinkingglasses{
-	pixel_y = 5;
-	pixel_x = 3
-	},
-/obj/item/reagent_containers/cup/beaker/bluespace{
-	pixel_x = -17;
-	pixel_y = 1
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"ou" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"ox" = (
-/obj/structure/rack/shelf,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets/donkpocketberry{
-	pixel_y = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"oL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/misc/condo)
-"oM" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/box,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"oO" = (
+"zi" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/trimline/dark_red/mid_joiner,
@@ -1325,19 +2574,35 @@
 	},
 /turf/open/floor/iron/shuttle/exploration/doubleside,
 /area/misc/condo)
-"oU" = (
-/obj/structure/scale,
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"oV" = (
-/obj/structure/table/optable,
-/obj/item/storage/backpack/duffelbag/syndie/surgery{
-	pixel_x = 0;
-	pixel_y = 4
-	},
+"zz" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/misc/condo)
-"pe" = (
+"zB" = (
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"zF" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side,
+/area/misc/condo)
+"zI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -1347,9 +2612,61 @@
 /obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 1
 	},
-/turf/open/floor/pod/dark,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
 /area/misc/condo)
-"pi" = (
+"zM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Af" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Ah" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/light/end{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west{
+	pixel_x = 0;
+	pixel_y = 13
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"Ap" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"Ar" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 6
 	},
@@ -1366,176 +2683,142 @@
 	},
 /turf/open/floor/carpet/red,
 /area/misc/condo)
-"pm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
+"At" = (
+/obj/structure/reagent_dispensers/servingdish{
+	name = "nutrislop dish";
+	desc = "Syndicate's finest, sloppest."
 	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/turf/open/floor/iron/shuttle/exploration/side,
+/turf/open/floor/carpet/red,
 /area/misc/condo)
-"pp" = (
-/obj/structure/rack/shelf{
-	pixel_x = 0;
-	pixel_y = 0
+"AJ" = (
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo"
 	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 4
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"AK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
+/area/misc/condo)
+"AQ" = (
+/obj/machinery/food_cart,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"AW" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/reagentgrinder,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -9;
+	pixel_y = -1
+	},
+/obj/machinery/light/directional/south,
+/obj/structure/sign/poster/contraband/chonk/directional/south,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Bf" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
-/obj/item/melee/baton/security/cattleprod/loaded{
-	pixel_x = -4;
-	pixel_y = -1
-	},
-/obj/item/melee/baton/security/cattleprod/loaded{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"pt" = (
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark/corner{
+/obj/effect/turf_decal/trimline/dark_green/line{
 	dir = 4
 	},
-/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side,
-/area/misc/condo)
-"px" = (
-/obj/item/grenade/chem_grenade/fatmix{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/holosign_creator/hardlight_wheelchair{
-	pixel_x = 14;
-	pixel_y = 9
-	},
-/obj/item/holosign_creator/hardlight_wheelchair{
-	pixel_x = 14;
-	pixel_y = 2
-	},
-/obj/item/holosign_creator/hardlight_wheelchair{
-	pixel_x = 14;
-	pixel_y = -5
-	},
-/obj/machinery/vending/wallmed/directional/north,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"py" = (
-/obj/effect/turf_decal/siding/dark/corner{
+/obj/effect/turf_decal/trimline/dark_green/line{
 	dir = 8
 	},
-/obj/structure/closet/firecloset/full,
-/obj/effect/turf_decal/box,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"pM" = (
-/obj/machinery/door/poddoor/shutters/window/preopen,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"pY" = (
-/obj/effect/turf_decal/stripes/red/line{
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
 	dir = 4
 	},
-/turf/open/floor/pod/dark,
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/half{
+	dir = 1
+	},
 /area/misc/condo)
-"qb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"Bk" = (
+/obj/structure/closet/crate{
+	name = "Pizza Storage"
+	},
+/obj/item/pizzabox/infinite,
+/obj/item/pizzabox/infinite,
+/obj/item/pizzabox/infinite,
+/obj/item/pizzabox/infinite,
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white/textured,
+/area/misc/condo)
+"Bp" = (
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/clothing/glasses/hud/health/night,
+/obj/item/gun/energy/fatoray,
+/obj/item/gun/energy/laser/alter_ray/gainrate,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/item/melee/baton/stunsword,
+/obj/item/melee/baton/stunsword,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"BG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"BN" = (
+/obj/machinery/deepfryer,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"BR" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 1
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = 16;
+	pixel_y = -16
 	},
-/turf/open/floor/iron/shuttle/exploration/side,
-/area/misc/condo)
-"qd" = (
-/obj/item/trash/can,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"qz" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"qB" = (
-/obj/structure/fluff/paper/stack{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/mineral/plastitanium/red,
-/area/misc/condo)
-"qC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"qD" = (
-/obj/structure/cable,
-/obj/structure/decorative/fluff{
-	icon = 'icons/turf/floors.dmi';
-	base_icon_state = "stairs-old";
-	icon_state = "stairs-m";
-	anchored = 1;
-	pixel_y = 0;
-	name = "staircase";
-	desc = "A small step for the humanity, and so is for you.";
-	dir = 8;
-	color = "#474747"
-	},
-/obj/structure/railing{
-	color = "#36373a";
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/blanktile,
-/area/misc/condo)
-"qJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
 /turf/open/floor/mineral/plastitanium,
 /area/misc/condo)
-"qP" = (
+"BS" = (
 /obj/structure/disposalpipe/junction/flip,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1555,178 +2838,114 @@
 /obj/effect/turf_decal/stripes/red/line,
 /turf/open/floor/pod/dark,
 /area/misc/condo)
-"qS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/side{
-	dir = 1
-	},
+"BX" = (
+/obj/machinery/suit_storage_unit/industrial/syndicatecontractor,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/dim/directional/west,
+/turf/open/floor/pod/dark,
 /area/misc/condo)
-"rg" = (
-/obj/effect/turf_decal/trimline/dark/corner{
+"BY" = (
+/obj/machinery/cryopod/quiet{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 8
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
 	},
-/obj/structure/chair/beanbag/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/mineral/plastitanium/red,
-/area/misc/condo)
-"ri" = (
-/obj/structure/flora/bush/grassy,
-/turf/open/misc/asteroid/airless,
-/area/misc/condo)
-"rk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/public/glass{
-	name = "Cell 4"
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"rl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/structure/railing/corner/end{
-	dir = 8;
-	color = "#36373a"
-	},
-/obj/structure/railing/corner/end{
-	dir = 8;
-	color = "#36373a";
-	pixel_x = 0;
-	pixel_y = -28
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/misc/condo)
-"rt" = (
+"Ci" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/exploration/side{
-	dir = 1
-	},
+/turf/open/floor/mineral/plastitanium,
 /area/misc/condo)
-"rH" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/structure/safe/abovetilefloor,
-/obj/item/stack/sheet/mineral/calorite/ten,
-/obj/item/stack/sheet/mineral/calorite/ten,
-/obj/item/stack/sheet/mineral/calorite/ten,
-/obj/structure/sign/flag/syndicate/directional/south,
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"rJ" = (
+"Cl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
-	dir = 8
-	},
 /area/misc/condo)
-"rN" = (
-/obj/structure/disposaloutlet{
+"Co" = (
+/obj/effect/turf_decal/trimline/dark/corner{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/misc/condo)
-"rO" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
-/obj/effect/turf_decal/siding/wideplating/light/end{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/end{
-	dir = 8
-	},
-/obj/structure/towel_bin{
-	pixel_x = 0;
-	pixel_y = -1
-	},
-/obj/structure/rack/shelf,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/white/diagonal,
-/area/misc/condo)
-"rP" = (
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 2
-	},
-/obj/effect/turf_decal/siding/dark/corner{
+/obj/effect/turf_decal/trimline/dark/corner{
 	dir = 4
 	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/mineral/plastitanium/red,
 /area/misc/condo)
-"rQ" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"sa" = (
+"Cs" = (
+/obj/item/trash/candy{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/obj/item/food/chocolatebar{
+	pixel_x = -4;
+	pixel_y = 9
+	},
 /obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 4
+	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	color = "#5d341f";
-	dir = 4;
-	use_holiday_colors = 0
+	dir = 8
 	},
 /turf/open/floor/wood/tile,
 /area/misc/condo)
-"sc" = (
+"Cu" = (
+/obj/structure/chair/sofa/corp/corner,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"CB" = (
+/obj/structure/chair/milking_machine,
+/turf/open/floor/hay,
+/area/misc/condo)
+"CM" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"CN" = (
+/obj/structure/chair/sofa/corp,
+/obj/item/food/pizzaslice/margherita,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"CZ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Db" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/microwave/frontier_printed,
+/obj/structure/sign/poster/contraband/eat/directional/south,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Dh" = (
+/obj/structure/reagent_dispensers/keg/lipoifier,
+/turf/open/floor/iron/shuttle/exploration/textured_flat,
+/area/misc/condo)
+"Dl" = (
 /obj/item/plate{
 	pixel_x = 12;
 	pixel_y = -1
@@ -1749,450 +2968,75 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/misc/condo)
-"se" = (
-/obj/structure/cable,
-/obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/siding/dark/corner{
+"Do" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Mini-Botany"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/misc/condo)
-"sf" = (
-/obj/structure/cable,
-/obj/item/storage/toolbox/syndicate{
-	pixel_x = 20;
-	pixel_y = 9
-	},
-/obj/item/organ/cyberimp/chest/nutriment/turbo{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/organ/cyberimp/chest/nutriment/turbo{
-	pixel_x = 10;
-	pixel_y = -13
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/misc/condo)
-"sn" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"sq" = (
-/obj/item/storage/box/ingredients/wildcard,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/structure/rack/shelf,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/item/storage/box/ingredients/wildcard,
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured,
-/area/misc/condo)
-"st" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"su" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"sy" = (
-/obj/structure/closet/crate{
-	name = "Pizza Storage"
-	},
-/obj/item/pizzabox/infinite,
-/obj/item/pizzabox/infinite,
-/obj/item/pizzabox/infinite,
-/obj/item/pizzabox/infinite,
-/obj/effect/turf_decal/siding/dark{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white/textured,
-/area/misc/condo)
-"sG" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/entertainment/plushie_delux,
-/obj/effect/spawner/random/entertainment/plushie_delux,
-/obj/effect/spawner/random/entertainment/plushie_delux,
-/obj/effect/spawner/random/bedsheet/any,
-/obj/effect/spawner/random/bedsheet/any,
-/obj/effect/spawner/random/bedsheet/any,
-/obj/effect/spawner/random/bedsheet/any,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"sO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/item/holosign_creator/atmos,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"tb" = (
-/obj/structure/railing{
-	color = "#36373a";
-	dir = 1
-	},
-/obj/structure/decorative/fluff{
-	icon = 'icons/turf/floors.dmi';
-	base_icon_state = "stairs-old";
-	icon_state = "stairs-m";
-	anchored = 1;
-	pixel_y = 0;
-	name = "staircase";
-	desc = "A small step for the humanity, and so is for you.";
-	dir = 4;
-	color = "#474747"
-	},
-/obj/structure/fake_stairs/directional/south{
-	icon_state = "stairs-old";
-	icon = 'icons/turf/floors.dmi';
-	color = "#555555";
-	dir = 8;
-	pixel_y = 1
-	},
-/obj/structure/fake_stairs/directional/south{
-	icon_state = "stairs-old";
-	icon = 'icons/turf/floors.dmi';
-	color = "#555555";
-	dir = 8;
-	pixel_y = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/blanktile,
-/area/misc/condo)
-"td" = (
-/obj/structure/gs13_fluff/brokenhose/scraps3{
-	pixel_x = -2;
-	pixel_y = -11
-	},
-/obj/structure/reagent_dispensers/cooking_oil/cream,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/misc/condo)
-"tr" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Office"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/misc/condo)
-"ts" = (
+"Dt" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light/end{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/end{
+	dir = 8
+	},
+/obj/structure/towel_bin{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/structure/rack/shelf,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"Dw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"tv" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/trimline/dark,
-/obj/effect/turf_decal/trimline/dark,
-/obj/effect/turf_decal/trimline/dark,
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"tw" = (
-/obj/machinery/food_cart,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"ty" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/effect/turf_decal/siding/wideplating_new/dark{
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured_large,
 /area/misc/condo)
-"tE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing{
-	color = "#36373a"
-	},
-/obj/structure/decorative/fluff{
-	icon = 'icons/turf/floors.dmi';
-	base_icon_state = "stairs-old";
-	icon_state = "stairs-m";
-	anchored = 1;
-	pixel_y = 0;
-	name = "staircase";
-	desc = "A small step for the humanity, and so is for you.";
-	dir = 4;
-	color = "#474747"
-	},
-/obj/structure/fake_stairs/directional/south{
-	icon_state = "stairs-old";
-	icon = 'icons/turf/floors.dmi';
-	color = "#555555";
-	dir = 8;
-	pixel_y = 1
-	},
-/obj/structure/fake_stairs/directional/south{
-	icon_state = "stairs-old";
-	icon = 'icons/turf/floors.dmi';
-	color = "#555555";
-	dir = 8;
-	pixel_y = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/blanktile,
-/area/misc/condo)
-"tN" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	color = "#5d341f";
-	dir = 8;
-	use_holiday_colors = 0
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"tX" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"tY" = (
-/obj/machinery/vending/clothing,
-/turf/open/floor/iron/shuttle/exploration/textured_flat,
-/area/misc/condo)
-"ui" = (
-/obj/effect/turf_decal/siding/dark/corner,
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"up" = (
-/obj/structure/decorative{
-	anchored = 1;
-	name = "wiring";
-	icon = 'icons/obj/machines/wallmounts.dmi';
-	icon_state = "apc2";
-	pixel_y = 23;
-	uses_integrity = 0;
-	pixel_x = 2
-	},
-/obj/structure/railing{
-	color = "#36373a"
-	},
-/obj/structure/decorative{
-	icon_state = "projector";
-	pixel_y = 5;
-	icon = 'modular_skyrat/modules/wargame_projectors/icons/projectors_and_holograms.dmi';
-	base_icon_state = "projector";
-	dir = 8;
-	pixel_x = 2;
-	anchored = 1;
-	name = "hologram projector"
-	},
-/obj/structure/decorative{
-	icon_state = "cell_charger_packed";
-	pixel_y = 9;
-	icon = 'modular_skyrat/modules/colony_fabricator/icons/packed_machines.dmi';
-	base_icon_state = "recharger";
-	dir = 8;
-	anchored = 1;
-	name = "glorpus";
-	pixel_x = 3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/shuttle/exploration/equipmentrail3,
-/area/misc/condo)
-"uy" = (
-/obj/item/book/manual/blubbery_bartender{
-	pixel_y = -4;
-	pixel_x = -4
-	},
-/obj/item/book/manual/fatty_chems{
-	pixel_y = -8;
-	pixel_x = -8
-	},
+"DA" = (
+/obj/structure/chair/comfy/shuttle,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark/corner,
-/obj/effect/turf_decal/trimline/dark/corner,
-/obj/effect/turf_decal/trimline/dark/corner,
-/obj/structure/decorative{
-	icon = 'icons/obj/tram/tram_controllers.dmi';
-	icon_state = "tram-controller";
-	anchored = 1;
-	name = "powerbox";
-	pixel_x = -30
-	},
-/obj/machinery/light/small/dim/directional/west,
-/turf/open/floor/iron/white/textured,
-/area/misc/condo)
-"uA" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	color = "#5d341f";
-	dir = 1;
-	use_holiday_colors = 0
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"uZ" = (
-/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
-	dir = 1
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/light/directional/south,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"vc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/doubleside,
-/area/misc/condo)
-"vi" = (
-/obj/machinery/space_heater,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/structure/decorative{
-	icon = 'icons/obj/tram/tram_controllers.dmi';
-	icon_state = "rectifier";
-	anchored = 1;
-	name = "powerbox";
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"vn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_green/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
-	dir = 4
-	},
 /obj/machinery/light/floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/mineral/plastitanium,
 /area/misc/condo)
-"vq" = (
+"DQ" = (
+/obj/structure/gs13_fluff/brokenhose/scraps1{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/machinery/power/adipoelectric_transformer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/misc/condo)
+"DW" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/biogenerator/foodricator,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"DX" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"Ea" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/railing/wooden_fence,
 /obj/effect/turf_decal/tile/neutral/half{
@@ -2207,18 +3051,157 @@
 /obj/machinery/iv_drip/gs13/plumbing_milker,
 /turf/open/floor/hay,
 /area/misc/condo)
-"vw" = (
+"Ec" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Shed"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"Ek" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/dark/corner{
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/iron/shuttle/exploration/side,
+/area/misc/condo)
+"El" = (
+/obj/machinery/vending/boozeomat/syndicate,
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Em" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Ep" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side{
+	dir = 1
+	},
+/area/misc/condo)
+"EC" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
+	dir = 4
+	},
+/area/misc/condo)
+"EF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 8
 	},
-/obj/machinery/vending/dinnerware{
-	free = 1
+/turf/open/floor/iron/shuttle/exploration/side,
+/area/misc/condo)
+"EQ" = (
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/space/basic,
+/area/misc/condo)
+"EW" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"EY" = (
+/obj/structure/flora/rock,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"Fd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/misc/condo)
+"Fg" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Fi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"Fl" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/open/floor/iron/small,
+/area/misc/condo)
+"Fv" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/processor{
+	pixel_x = 1;
+	pixel_y = 8
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/misc/condo)
-"vz" = (
+"FE" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"FN" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Freezer"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"FP" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"FR" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/structure/railing/corner/end{
 	dir = 8;
@@ -2269,1097 +3252,7 @@
 	},
 /turf/open/floor/iron/white/diagonal,
 /area/misc/condo)
-"vF" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
-/obj/machinery/light/floor{
-	brightness = 7.5;
-	pixel_x = -16;
-	pixel_y = -16
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"vG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/half{
-	dir = 1
-	},
-/area/misc/condo)
-"vM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/machinery/space_heater/wall_mounted/directional/north{
-	cell = /obj/item/stock_parts/power_store/cell/high;
-	pixel_y = -30
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"vT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Cell 2"
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"vV" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"wb" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/chem_dispenser/frontier_appliance,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"wc" = (
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"wo" = (
-/obj/item/trash/boritos{
-	pixel_x = 18;
-	pixel_y = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"wy" = (
-/obj/structure/sink/kitchen/directional/south,
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"wB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"wE" = (
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"wP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"xa" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Cell 3"
-	},
-/obj/structure/fans/tiny/forcefield,
-/obj/structure/fans/tiny,
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"xd" = (
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/hay,
-/area/misc/condo)
-"xr" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"xs" = (
-/obj/machinery/deepfryer,
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"xu" = (
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating/light{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding{
-	dir = 10
-	},
-/turf/open/floor/iron/white/diagonal,
-/area/misc/condo)
-"xv" = (
-/obj/structure/gs13_fluff/brokenhose{
-	pixel_x = -1;
-	pixel_y = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/misc/condo)
-"xQ" = (
-/turf/open/floor/iron/shuttle/exploration/uside{
-	dir = 4
-	},
-/area/misc/condo)
-"xR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 1;
-	name = "O2 To Pure"
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/lipoifium,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/misc/condo)
-"yj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy";
-	pixel_x = 17;
-	pixel_y = -16
-	},
-/obj/machinery/light/floor{
-	brightness = 7.5;
-	pixel_x = 16;
-	pixel_y = -16
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/misc/condo)
-"yo" = (
-/obj/item/trash/vendor_trash/lizard_bag,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"yr" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"yE" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 5
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/item/bedsheet/syndie,
-/obj/structure/bed/pod,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"yS" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/misc/condo)
-"yV" = (
-/obj/structure/reagent_dispensers/servingdish{
-	name = "nutrislop dish";
-	desc = "Syndicate's finest, sloppest."
-	},
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"yX" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"yY" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/hydroponics,
-/obj/item/circuitboard/machine/hydroponics,
-/obj/item/circuitboard/machine/hydroponics,
-/obj/item/storage/box/disks_plantgene,
-/obj/item/storage/box/disks_plantgene,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"zf" = (
-/obj/effect/turf_decal/siding/wideplating/light/end{
-	dir = 1
-	},
-/obj/structure/toilet,
-/obj/machinery/light/small/directional/east{
-	pixel_x = 0;
-	pixel_y = -11
-	},
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"zh" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 5
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 5
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/misc/condo)
-"zz" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 9
-	},
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"zD" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/hay,
-/area/misc/condo)
-"zR" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"zS" = (
-/obj/machinery/iv_drip/gs13/plumbing_feeder,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/misc/condo)
-"zX" = (
-/turf/open/misc/asteroid/airless,
-/area/misc/condo)
-"zZ" = (
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red,
-/turf/open/floor/plating,
-/area/misc/condo)
-"Ab" = (
-/obj/item/reagent_containers/cup/bottle/succubus_milk{
-	pixel_x = 7;
-	pixel_y = 14
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"Ag" = (
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"Ap" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/structure/railing{
-	color = "#36373a"
-	},
-/obj/item/training_toolbox{
-	name = "ambiguous toolbox";
-	icon_state = "coroner";
-	desc = "Don't cum on the servers.";
-	pixel_x = 10;
-	pixel_y = 3
-	},
-/obj/item/screwdriver{
-	pixel_x = -1;
-	pixel_y = 13
-	},
-/obj/structure/decorative{
-	icon_state = "wallmount";
-	pixel_y = 31;
-	icon = 'icons/obj/science/circuits.dmi';
-	dir = 8;
-	anchored = 1;
-	name = "wallmount"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/shuttle/exploration/equipmentrail2,
-/area/misc/condo)
-"Au" = (
-/obj/structure/rack/shelf,
-/obj/item/storage/box/donkpockets/donkpockethonk,
-/obj/item/storage/box/donkpockets/donkpocketpizza{
-	pixel_y = 4
-	},
-/obj/item/storage/box/donkpockets/donkpocketspicy{
-	pixel_y = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Av" = (
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
-	dir = 8
-	},
-/area/misc/condo)
-"AB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/side{
-	dir = 1
-	},
-/area/misc/condo)
-"AC" = (
-/obj/machinery/suit_storage_unit/industrial/syndicatecontractor,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"AJ" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	color = "#5d341f";
-	dir = 1;
-	use_holiday_colors = 0
-	},
-/obj/item/plate_shard{
-	pixel_x = -1;
-	pixel_y = 9
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"AY" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 2
-	},
-/obj/machinery/light/floor{
-	brightness = 7.5;
-	pixel_x = 16;
-	pixel_y = -16
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"Bd" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/machinery/power/rtg/debug,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/misc/condo)
-"Bh" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/misc/condo)
-"Bk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/misc/condo)
-"Bo" = (
-/obj/machinery/iv_drip/gs13/plumbing_milker,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/misc/condo)
-"Bx" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
-/obj/effect/turf_decal/siding/wideplating/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding{
-	dir = 8
-	},
-/turf/open/floor/iron/white/diagonal,
-/area/misc/condo)
-"BO" = (
-/obj/structure/table,
-/obj/structure/decorative{
-	icon_state = "intercom";
-	pixel_y = 31;
-	icon = 'icons/obj/machines/wallmounts.dmi';
-	base_icon_state = "tile_half";
-	dir = 8;
-	anchored = 1;
-	name = "Intercom";
-	desc = "An older model version of a standard intercom system."
-	},
-/obj/item/plate{
-	pixel_x = 0;
-	pixel_y = -1
-	},
-/obj/item/plate{
-	pixel_x = 3;
-	pixel_y = 1
-	},
-/obj/item/plate{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/plate{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/plate{
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/obj/item/plate{
-	pixel_x = 2;
-	pixel_y = 9
-	},
-/obj/item/plate{
-	pixel_x = 0;
-	pixel_y = 12
-	},
-/obj/item/plate{
-	pixel_x = 1;
-	pixel_y = 14
-	},
-/obj/item/plate{
-	pixel_x = 1;
-	pixel_y = 16
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"BX" = (
-/turf/open/floor/circuit/red,
-/area/misc/condo)
-"BY" = (
-/obj/machinery/shower/directional/west,
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
-/obj/effect/turf_decal/siding/wideplating/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding{
-	dir = 4
-	},
-/obj/structure/decorative{
-	icon_state = "drain";
-	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
-	base_icon_state = "drain";
-	dir = 8;
-	name = "drain";
-	anchored = 1;
-	pixel_x = -1
-	},
-/turf/open/floor/iron/white/diagonal,
-/area/misc/condo)
-"Ca" = (
-/obj/item/clothing/mask/leatherwhip,
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"Cc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/exploration/side{
-	dir = 1
-	},
-/area/misc/condo)
-"Cf" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/trimline/dark{
-	pixel_x = 0;
-	pixel_y = 16
-	},
-/obj/effect/turf_decal/trimline/dark{
-	pixel_x = 0;
-	pixel_y = 16
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/misc/condo)
-"Cl" = (
-/obj/machinery/computer/security/telescreen/entertainment,
-/turf/closed/wall/r_wall/plastitanium/syndicate,
-/area/misc/condo)
-"Cm" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/reagent_dispensers/cooking_oil/cream/open,
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"Cr" = (
-/obj/structure/rack/shelf,
-/obj/item/storage/box/beakers,
-/obj/item/reagent_containers/cup/soda_cans/air,
-/obj/item/reagent_containers/cup/soda_cans/beer,
-/obj/item/reagent_containers/cup/soda_cans/beer/rice,
-/obj/item/reagent_containers/cup/soda_cans/blood_tea,
-/obj/item/reagent_containers/cup/soda_cans/canned_laughter,
-/obj/item/reagent_containers/cup/soda_cans/cola,
-/obj/item/reagent_containers/cup/soda_cans/dr_gibb,
-/obj/item/reagent_containers/cup/soda_cans/fizzwiz,
-/obj/item/reagent_containers/cup/soda_cans/grey_bull,
-/obj/item/reagent_containers/cup/soda_cans/lemon_lime,
-/obj/item/reagent_containers/cup/soda_cans/melon_soda,
-/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
-/obj/item/reagent_containers/cup/soda_cans/pwr_game,
-/obj/item/reagent_containers/cup/soda_cans/shamblers,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Cu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Cz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"CC" = (
-/obj/machinery/autolathe/hacked,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark/corner,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"CN" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 2
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/shuttle/exploration/corner_invcorner,
-/area/misc/condo)
-"CP" = (
-/obj/structure/flora/rock,
-/turf/open/misc/asteroid/airless,
-/area/misc/condo)
-"Df" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"Dl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_red/corner,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
-/obj/machinery/light/floor{
-	brightness = 7.5;
-	pixel_x = 16;
-	pixel_y = -16
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side,
-/area/misc/condo)
-"Dy" = (
-/obj/structure/sink/directional/west,
-/obj/structure/mirror/directional/east,
-/obj/effect/turf_decal/siding/wideplating/light/end{
-	dir = 4
-	},
-/obj/structure/decorative{
-	icon_state = "drain";
-	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
-	base_icon_state = "drain";
-	dir = 8;
-	name = "drain";
-	anchored = 1;
-	pixel_x = -16;
-	pixel_y = 0
-	},
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"Dz" = (
-/obj/structure/chair/sofa/corp,
-/obj/item/reagent_containers/cup/bowl,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"DJ" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/structure/fluff/paper/stack{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"DN" = (
-/obj/structure/gs13_fluff/brokenhose/scraps1{
-	pixel_x = 4;
-	pixel_y = 1
-	},
-/obj/machinery/power/adipoelectric_transformer,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/misc/condo)
-"DW" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 6
-	},
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/turf/open/floor/iron/small,
-/area/misc/condo)
-"Ee" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Cell 3"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"Em" = (
-/obj/structure/falsewall/plastitanium,
-/obj/structure/fans/tiny/invisible,
-/turf/open/floor/plating,
-/area/misc/condo)
-"Es" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/doubleside,
-/area/misc/condo)
-"ED" = (
-/obj/machinery/vending/dorms,
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"EF" = (
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
-/obj/effect/turf_decal/siding/wideplating/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding{
-	dir = 4
-	},
-/obj/machinery/shower/directional/west,
-/obj/structure/decorative{
-	icon_state = "drain";
-	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
-	base_icon_state = "drain";
-	dir = 8;
-	name = "drain";
-	anchored = 1;
-	pixel_x = -1
-	},
-/turf/open/floor/iron/white/diagonal,
-/area/misc/condo)
-"EK" = (
-/obj/structure/closet/emcloset/anchored,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"EO" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"ET" = (
-/obj/structure/scale,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"EU" = (
-/obj/structure/reagent_dispensers/keg/lipoifier,
-/turf/open/floor/iron/shuttle/exploration/textured_flat,
-/area/misc/condo)
-"Fd" = (
-/obj/structure/scale,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"Fe" = (
-/obj/machinery/vending/mealdor{
-	free = 1
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"Fm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall/plastitanium/syndicate,
-/area/misc/condo)
-"Fp" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/misc/condo)
-"Fx" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/iron/shuttle/exploration/equipmentrail2,
-/area/misc/condo)
-"FG" = (
-/obj/structure/chair/comfy/shuttle,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"FV" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	color = "#5d341f";
-	dir = 1;
-	use_holiday_colors = 0
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"FW" = (
-/obj/machinery/cryopod/quiet{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
-/obj/structure/decorative{
-	icon = 'icons/obj/machines/wallmounts.dmi';
-	icon_state = "tram";
-	pixel_x = 28;
-	pixel_y = 11;
-	dir = 1;
-	name = "curtain button"
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Gu" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 10
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Gz" = (
-/obj/structure/flora/bush/jungle/b/style_3,
-/turf/open/misc/asteroid/airless,
-/area/misc/condo)
-"GM" = (
-/obj/structure/reagent_dispensers/servingdish{
-	name = "nutrislop dish";
-	desc = "Syndicate's finest, sloppest."
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"GV" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/misc/condo)
-"Hb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side{
-	dir = 1
-	},
-/area/misc/condo)
-"Hh" = (
-/obj/structure/railing{
-	color = "#36373a";
-	dir = 1
-	},
-/obj/structure/railing{
-	color = "#36373a"
-	},
-/obj/structure/fake_stairs/directional/south{
-	icon_state = "stairs-old";
-	icon = 'icons/turf/floors.dmi';
-	color = "#555555";
-	dir = 8;
-	pixel_y = 1
-	},
-/turf/open/floor/plating,
-/area/misc/condo)
-"Hn" = (
-/obj/item/plate{
-	pixel_x = 8;
-	pixel_y = -4
-	},
-/obj/item/plate{
-	pixel_x = 9;
-	pixel_y = -2
-	},
-/obj/item/plate{
-	pixel_x = 8;
-	pixel_y = 0
-	},
-/obj/item/plate_shard{
-	pixel_x = -3;
-	pixel_y = -7
-	},
-/obj/item/plate_shard{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"Hv" = (
-/obj/machinery/plantgenes{
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/turf/open/floor/iron/shuttle/exploration,
-/area/misc/condo)
-"Hx" = (
-/obj/structure/chair/sofa/corp,
-/obj/item/trash/boritos{
-	pixel_x = 0;
-	pixel_y = -2
-	},
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"HA" = (
-/obj/structure/rack/shelf,
-/obj/item/storage/fancy/donut_box{
-	pixel_y = -4
-	},
-/obj/item/storage/fancy/donut_box,
-/obj/item/storage/fancy/donut_box{
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/siding/dark/corner,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"HP" = (
-/obj/structure/chair/milking_machine,
-/turf/open/floor/hay,
-/area/misc/condo)
-"HY" = (
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 2
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/exploration/corner_invcorner,
-/area/misc/condo)
-"Ie" = (
+"FU" = (
 /obj/structure/railing/corner/end{
 	dir = 8;
 	color = "#36373a"
@@ -3390,7 +3283,686 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/mineral/plastitanium,
 /area/misc/condo)
+"Gc" = (
+/obj/machinery/smartfridge/food,
+/obj/item/food/taco,
+/obj/item/food/nigiri_sushi,
+/obj/item/food/spaghetti/pastatomato,
+/obj/item/reagent_containers/cup/glass/bottle/small{
+	pixel_x = -11;
+	pixel_y = 19
+	},
+/obj/item/reagent_containers/cup/glass/bottle/small{
+	pixel_x = -2;
+	pixel_y = 19
+	},
+/obj/item/reagent_containers/cup/glass/bottle{
+	pixel_x = 8;
+	pixel_y = 22
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Gf" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/open/floor/iron/small,
+/area/misc/condo)
+"Gj" = (
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 4
+	},
+/area/misc/condo)
+"GJ" = (
+/obj/structure/filingcabinet,
+/obj/item/folder/syndicate/mining,
+/obj/item/folder/syndicate/red,
+/turf/open/floor/circuit/red,
+/area/misc/condo)
+"GO" = (
+/obj/structure/chair/sofa/corp,
+/obj/item/gun/energy/laser/alter_ray/noloss{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Ha" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Mini-Botany"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"Hd" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/oven/range_frontier,
+/obj/item/reagent_containers/cup/soup_pot,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"Hj" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/chair/beanbag/red{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Hr" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron/shuttle/exploration/equipmentrail2,
+/area/misc/condo)
+"HC" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/half{
+	dir = 1
+	},
+/area/misc/condo)
+"HI" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets/donkpocketberry{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"HN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing{
+	color = "#36373a"
+	},
+/obj/structure/decorative/fluff{
+	icon = 'icons/turf/floors.dmi';
+	base_icon_state = "stairs-old";
+	icon_state = "stairs-m";
+	anchored = 1;
+	pixel_y = 0;
+	name = "staircase";
+	desc = "A small step for the humanity, and so is for you.";
+	dir = 4;
+	color = "#474747"
+	},
+/obj/structure/fake_stairs/directional/south{
+	icon_state = "stairs-old";
+	icon = 'icons/turf/floors.dmi';
+	color = "#555555";
+	dir = 8;
+	pixel_y = 1
+	},
+/obj/structure/fake_stairs/directional/south{
+	icon_state = "stairs-old";
+	icon = 'icons/turf/floors.dmi';
+	color = "#555555";
+	dir = 8;
+	pixel_y = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
 "If" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Ih" = (
+/obj/item/clothing/mask/leatherwhip,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Is" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Iv" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/structure/rack/shelf,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/item/melee/baton/telescopic{
+	pixel_x = -3;
+	pixel_y = 10
+	},
+/obj/item/melee/baton/telescopic{
+	pixel_x = 11;
+	pixel_y = 10
+	},
+/obj/item/melee/baton/telescopic{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"IA" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"IK" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/obj/item/kitchen/spoon/soup_ladle{
+	name = "sauna ladle";
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"IU" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"Ja" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"Je" = (
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"Jh" = (
+/obj/item/plate{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/plate{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/plate{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/obj/item/plate_shard{
+	pixel_x = -3;
+	pixel_y = -7
+	},
+/obj/item/plate_shard{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Jk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/machinery/space_heater/wall_mounted/directional/north{
+	cell = /obj/item/stock_parts/power_store/cell/high;
+	pixel_y = -30
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"JF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/item/food/grown/lipofruit,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/misc/condo)
+"JI" = (
+/obj/structure/reagent_dispensers/keg/lipoifier,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"JO" = (
+/obj/structure/gs13_fluff/brokenhose/scraps3,
+/turf/open/floor/hay,
+/area/misc/condo)
+"JW" = (
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/structure/rack/shelf,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
+/area/misc/condo)
+"Kl" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 2
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Kw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/half{
+	dir = 1
+	},
+/area/misc/condo)
+"KB" = (
+/obj/item/trash/vendor_trash/lizard_bag,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"KC" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/box/handcuffs{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"KE" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"KG" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/trimline/dark_red,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"KQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/item/holosign_creator/atmos,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"KR" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/multitool,
+/obj/item/clothing/head/utility/welding,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"La" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Lf" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"Ln" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"Lo" = (
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red,
+/turf/open/floor/plating,
+/area/misc/condo)
+"Lr" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Lv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/structure/railing{
+	color = "#36373a"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/dim/directional/west,
+/turf/open/floor/iron/shuttle/exploration/equipmentrail1,
+/area/misc/condo)
+"Lx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"Ly" = (
+/obj/structure/chair/sofa/corp,
+/obj/item/trash/boritos{
+	pixel_x = 0;
+	pixel_y = -2
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"LG" = (
+/obj/structure/sign/poster/contraband/corn_oil,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
+/area/misc/condo)
+"LH" = (
+/obj/vehicle/ridden/wheelchair,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"LP" = (
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/machinery/shower/directional/west,
+/obj/structure/decorative{
+	icon_state = "drain";
+	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
+	base_icon_state = "drain";
+	dir = 8;
+	name = "drain";
+	anchored = 1;
+	pixel_x = -1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"LS" = (
+/obj/structure/decorative{
+	anchored = 1;
+	name = "wiring";
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	icon_state = "apc2";
+	pixel_y = 23;
+	uses_integrity = 0;
+	pixel_x = 2
+	},
+/obj/structure/railing{
+	color = "#36373a"
+	},
+/obj/structure/decorative{
+	icon_state = "projector";
+	pixel_y = 5;
+	icon = 'modular_skyrat/modules/wargame_projectors/icons/projectors_and_holograms.dmi';
+	base_icon_state = "projector";
+	dir = 8;
+	pixel_x = 2;
+	anchored = 1;
+	name = "hologram projector"
+	},
+/obj/structure/decorative{
+	icon_state = "cell_charger_packed";
+	pixel_y = 9;
+	icon = 'modular_skyrat/modules/colony_fabricator/icons/packed_machines.dmi';
+	base_icon_state = "recharger";
+	dir = 8;
+	anchored = 1;
+	name = "glorpus";
+	pixel_x = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/shuttle/exploration/equipmentrail3,
+/area/misc/condo)
+"Mc" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Mw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Milking Chamber"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"MF" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"MI" = (
+/obj/machinery/iv_drip/feeding_tube,
+/obj/structure/sign/poster/contraband/chonk/directional/north,
+/turf/open/floor/hay,
+/area/misc/condo)
+"MJ" = (
+/obj/machinery/shower/directional/east,
+/obj/structure/decorative{
+	icon_state = "drain";
+	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
+	base_icon_state = "drain";
+	dir = 8;
+	name = "drain";
+	anchored = 1;
+	pixel_x = -1
+	},
+/obj/effect/turf_decal/siding/wideplating/light/end{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/light/end{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"MM" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/light/floor{
+	pixel_x = 0;
+	pixel_y = -16
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"MZ" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Nc" = (
+/obj/item/screwdriver,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"Nd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/railing{
 	color = "#36373a";
@@ -3416,84 +3988,584 @@
 	pixel_x = 0;
 	pixel_y = -23
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/misc/condo)
-"Ig" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 10
+"Nf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 10
-	},
-/turf/open/floor/iron/white/small,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/structure/sign/poster/contraband/chefpropaganda/directional/south,
+/turf/open/floor/mineral/plastitanium,
 /area/misc/condo)
-"Im" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
+"Nh" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/power/rtg/debug,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/misc/condo)
+"Ni" = (
+/turf/closed/mineral/random,
+/area/misc/condo)
+"Nj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cell 1"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"Nq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing/corner/end{
+	dir = 4;
+	color = "#36373a"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#59595a";
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Nt" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"Nv" = (
+/obj/structure/rack/shelf,
+/obj/item/trash/syndi_cakes,
+/obj/item/trash/syndi_cakes,
+/obj/item/food/chips,
+/obj/item/food/chips,
+/obj/item/food/cornchips,
+/obj/item/food/cornchips,
+/obj/item/food/candy,
+/obj/item/food/candy,
+/obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
 	},
-/obj/machinery/iv_drip/feeding_tube,
+/obj/structure/sign/poster/contraband/syndicate_pistol/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"NB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/implantchair/brainwash,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"NG" = (
+/obj/item/plate/large,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"NI" = (
+/turf/closed/indestructible/hoteldoor{
+	icon_state = "closed";
+	icon = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/external/external.dmi'
+	},
+/area/misc/condo)
+"NR" = (
+/obj/machinery/suit_storage_unit/industrial/syndicatecontractor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"NS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"NW" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy"
+	},
+/obj/machinery/porta_turret/syndicate/fattening,
+/turf/open/floor/plating,
+/area/misc/condo)
+"Ob" = (
+/obj/item/trash/boritos{
+	pixel_x = 18;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood/tile,
 /area/misc/condo)
-"Iy" = (
-/obj/structure/rack/shelf,
-/obj/item/stack/sheet/cardboard{
-	amount = 3
+"Oe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/item/stack/sheet/cardboard{
-	amount = 3
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
 	},
-/obj/item/stack/sheet/cardboard{
-	amount = 3
-	},
-/obj/item/stack/sheet/cardboard{
-	amount = 3
-	},
-/obj/item/stack/rods/twentyfive,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/machinery/power/terminal{
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
 	dir = 1
 	},
-/obj/item/storage/box/stockparts/deluxe,
-/obj/item/storage/box/stockparts/deluxe,
-/obj/item/storage/box/stockparts/deluxe,
-/obj/item/storage/box/stockparts/deluxe,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner/end{
+	dir = 8;
+	color = "#36373a"
+	},
+/obj/structure/railing/corner/end{
+	dir = 8;
+	color = "#36373a";
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Of" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"OB" = (
+/obj/vehicle/ridden/wheelchair,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"OK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"Pe" = (
+/turf/open/floor/circuit/red,
+/area/misc/condo)
+"Pp" = (
+/obj/structure/scale,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"PI" = (
+/obj/structure/rack/shelf,
+/obj/item/electropack/shockcollar,
+/obj/item/clothing/neck/petcollar,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs/cable/zipties,
+/obj/item/clothing/mask/ballgag,
+/obj/item/clothing/mask/ballgag,
+/obj/item/clothing/mask/ballgag/choking,
+/obj/item/clothing/mask/ballgag/choking,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"PR" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"PS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy";
+	pixel_x = 17;
+	pixel_y = -16
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"Qf" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Power"
+	},
 /obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"Qg" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
 /turf/open/floor/pod/dark,
 /area/misc/condo)
-"IB" = (
-/obj/item/bodybag/bluespace,
+"Qj" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side,
+/area/misc/condo)
+"Qk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
 /turf/open/floor/pod/dark,
 /area/misc/condo)
-"IC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/oven/range_frontier,
-/obj/item/reagent_containers/cup/soup_pot,
+"Ql" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleside,
+/area/misc/condo)
+"QB" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/structure/decorative{
+	icon = 'modular_skyrat/modules/advanced_shuttles/icons/computer.dmi';
+	icon_state = "computer_right";
+	anchored = 1
+	},
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = 31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system."
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"QK" = (
+/obj/machinery/vending/fatty_items,
+/turf/open/floor/iron/shuttle/exploration/textured_flat,
+/area/misc/condo)
+"QP" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"QW" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/fancy/large_donut_box{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/item/storage/fancy/large_donut_box{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/item/storage/fancy/large_donut_box{
+	pixel_x = 0;
+	pixel_y = 14
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Ra" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/chem_dispenser/frontier_appliance,
+/obj/structure/sign/poster/contraband/corn_oil/directional/south,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Rb" = (
+/obj/structure/scale,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Rg" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/box/donkpockets/donkpockethonk,
+/obj/item/storage/box/donkpockets/donkpocketpizza{
+	pixel_y = 4
+	},
+/obj/item/storage/box/donkpockets/donkpocketspicy{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Rm" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/white/small,
 /area/misc/condo)
-"IF" = (
+"Rn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
 /turf/open/floor/pod/dark,
 /area/misc/condo)
-"IM" = (
+"Rp" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 4;
+	use_holiday_colors = 0
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Ru" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/decorative/fluff{
+	icon = 'icons/turf/floors.dmi';
+	base_icon_state = "stairs-old";
+	icon_state = "stairs-m";
+	anchored = 1;
+	pixel_y = 0;
+	name = "staircase";
+	desc = "A small step for the humanity, and so is for you.";
+	dir = 8;
+	color = "#474747"
+	},
+/obj/structure/railing{
+	color = "#36373a"
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"RJ" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/misc/condo)
+"RM" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"RO" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"RS" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/obj/structure/sign/poster/official/calorite/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Sc" = (
+/obj/item/trash/candy,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Se" = (
+/obj/structure/sink/kitchen/directional/south,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"Sz" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"SC" = (
+/turf/closed/indestructible/hotelwall{
+	color = "#000000"
+	},
+/area/misc/condo)
+"SD" = (
+/obj/item/paper/fluff/ruins/feeder_den/hidden,
+/turf/open/floor/plating,
+/area/misc/condo)
+"SF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"SH" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"SK" = (
+/obj/item/storage/bag/plants,
+/obj/effect/turf_decal/siding/dark/end,
+/obj/effect/turf_decal/trimline/dark_green/end,
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 8
+	},
+/turf/open/floor/iron/half{
+	dir = 1
+	},
+/area/misc/condo)
+"SY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/machinery/space_heater/wall_mounted/directional/north{
+	cell = /obj/item/stock_parts/power_store/cell/high;
+	pixel_y = -30
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"SZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/dark_red/corner{
@@ -3507,83 +4579,446 @@
 	dir = 1
 	},
 /area/misc/condo)
-"IO" = (
-/obj/structure/ore_box,
-/turf/open/floor/iron/dark/textured_large,
+"Ta" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/trimline/dark,
+/turf/open/floor/iron/shuttle/exploration/doubleside,
 /area/misc/condo)
-"Ji" = (
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark/corner,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
-	dir = 4
-	},
-/area/misc/condo)
-"Jj" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/obj/structure/filingcabinet,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper,
-/obj/item/paper/fluff/ruins/feeder_den/report3,
-/obj/item/paper/fluff/ruins/feeder_den/report2,
-/obj/item/paper/fluff/ruins/feeder_den/report1,
-/obj/structure/fluff/paper/stack{
-	pixel_x = -14;
-	pixel_y = 16
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+"Tc" = (
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/structure/sign/flag/syndicate/directional/south,
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/dark/textured_large,
 /area/misc/condo)
-"Jp" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/siding/wood,
+"Th" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /turf/open/floor/wood/tile,
 /area/misc/condo)
-"Jx" = (
+"Tj" = (
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/trimline/dark/corner,
+/obj/effect/turf_decal/trimline/dark/corner,
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"Ts" = (
+/obj/structure/flora/bush/jungle/b/style_3,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"Tt" = (
+/obj/structure/cable,
+/obj/structure/decorative/fluff{
+	icon = 'icons/turf/floors.dmi';
+	base_icon_state = "stairs-old";
+	icon_state = "stairs-m";
+	anchored = 1;
+	pixel_y = 0;
+	name = "staircase";
+	desc = "A small step for the humanity, and so is for you.";
+	dir = 8;
+	color = "#474747"
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"Tz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"TH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"TV" = (
+/obj/structure/rack,
+/obj/item/mop/advanced,
+/obj/item/storage/bag/trash,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Ub" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/obj/structure/sign/warning/radiation/directional/south,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"Uk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleside,
+/area/misc/condo)
+"Uu" = (
+/obj/structure/closet/wardrobe/mixed,
+/turf/open/floor/iron/shuttle/exploration/textured_flat,
+/area/misc/condo)
+"UA" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"UB" = (
+/obj/item/bodybag/bluespace,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"UE" = (
+/obj/item/storage/toolbox/syndicate,
+/obj/machinery/power/port_gen/pacman/super,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"UF" = (
 /obj/structure/flora/bush/jungle/b/style_3,
 /obj/structure/flora/rock/pile,
 /turf/open/misc/asteroid/airless,
 /area/misc/condo)
-"JD" = (
+"UH" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"UJ" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/vending/mealdor{
+	free = 1
+	},
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"UU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"UZ" = (
+/obj/machinery/vending/mealdor{
+	free = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"Vd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/corner,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side,
+/area/misc/condo)
+"Ve" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
+	dir = 4
+	},
+/area/misc/condo)
+"Vg" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/railing/wooden_fence,
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 2
+	},
+/turf/open/floor/hay,
+/area/misc/condo)
+"Vu" = (
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 5;
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/cup/beaker/bluespace{
+	pixel_x = -17;
+	pixel_y = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Vw" = (
+/obj/machinery/power/port_gen/pacman/super,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"VA" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/hatch{
+	name = "Entrance Airlock"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"VC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"VD" = (
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/misc/condo)
+"VI" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/marker_beacon/cerulean,
+/turf/open/floor/iron/small,
+/area/misc/condo)
+"Wh" = (
+/obj/structure/flora/bush/jungle,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"Wk" = (
+/obj/structure/reagent_dispensers/servingdish{
+	name = "nutrislop dish";
+	desc = "Syndicate's finest, sloppest."
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Wq" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/open/floor/iron/small,
+/area/misc/condo)
+"WA" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"WE" = (
+/obj/machinery/cryopod/quiet{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"WI" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/condiment/ketchup{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/plate{
+	pixel_x = -10;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"WL" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"WN" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"WV" = (
+/obj/machinery/vending/fatty_items,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Xa" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/item/bedsheet/syndie,
+/obj/structure/bed/pod,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Xs" = (
+/obj/structure/cable,
+/obj/structure/railing/corner/end{
+	dir = 4;
+	color = "#36373a";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#59595a";
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/misc/condo)
-"JI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"Xw" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/carpet/red,
 /area/misc/condo)
-"JU" = (
+"Xx" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Testing Chamber"
+	},
+/obj/structure/fans/tiny/forcefield,
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"XO" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Office"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"XQ" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 1;
+	use_holiday_colors = 0
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"XS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3615,1509 +5050,41 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/half,
 /area/misc/condo)
-"JZ" = (
-/obj/item/food/burger/greaseburger{
-	pixel_x = 1;
-	pixel_y = 14
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"Kb" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/reagent_containers/condiment/enzyme{
-	pixel_x = 3;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/condiment/ketchup{
-	pixel_x = 10;
-	pixel_y = 2
-	},
-/obj/item/plate{
-	pixel_x = -10;
-	pixel_y = -2
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"Ke" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
+"XT" = (
+/obj/machinery/autolathe/hacked,
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark,
 /area/misc/condo)
-"Kf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/shuttle/exploration/side,
-/area/misc/condo)
-"Ko" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"Kz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/decorative/fluff{
-	icon = 'icons/turf/floors.dmi';
-	base_icon_state = "stairs-old";
-	icon_state = "stairs-m";
-	anchored = 1;
-	pixel_y = 0;
-	name = "staircase";
-	desc = "A small step for the humanity, and so is for you.";
-	dir = 8;
-	color = "#474747"
-	},
-/obj/structure/railing{
-	color = "#36373a"
-	},
-/turf/open/floor/iron/shuttle/exploration/blanktile,
-/area/misc/condo)
-"KL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/misc/condo)
-"KN" = (
-/obj/item/trash/tray,
+"XY" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 8
+	dir = 10
 	},
 /obj/effect/turf_decal/siding/wood{
-	dir = 8
+	dir = 10
 	},
-/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/safe/abovetilefloor,
+/obj/item/stack/sheet/mineral/calorite/ten,
+/obj/item/stack/sheet/mineral/calorite/ten,
+/obj/item/stack/sheet/mineral/calorite/ten,
+/obj/structure/sign/flag/syndicate/directional/south,
 /turf/open/floor/wood/tile,
 /area/misc/condo)
-"KU" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/trimline/dark,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/misc/condo)
-"Ll" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy"
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Lx" = (
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy"
-	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/porta_turret/syndicate/fattening,
-/turf/open/floor/plating,
-/area/misc/condo)
-"LB" = (
-/obj/structure/rack/shelf,
-/obj/item/electropack/shockcollar,
-/obj/item/clothing/neck/petcollar,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs/cable/zipties,
-/obj/item/clothing/mask/ballgag,
-/obj/item/clothing/mask/ballgag,
-/obj/item/clothing/mask/ballgag/choking,
-/obj/item/clothing/mask/ballgag/choking,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"LH" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/railing/wooden_fence,
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	color = "#5d341f";
-	dir = 2
-	},
-/turf/open/floor/hay,
-/area/misc/condo)
-"Mr" = (
-/obj/structure/reagent_dispensers/keg/lipoifier,
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"Ms" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
-/obj/effect/turf_decal/siding/wideplating/light/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating/light/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white/diagonal,
-/area/misc/condo)
-"ME" = (
-/obj/machinery/door/airlock/hatch,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"MK" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Junk Shed"
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"MO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"Ya" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/public/glass{
 	name = "Cell 1"
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/misc/condo)
-"MU" = (
-/obj/machinery/recharger,
-/obj/item/implanter{
-	pixel_x = 9;
-	pixel_y = 15
-	},
-/obj/item/implanter{
-	pixel_x = 9;
-	pixel_y = 11
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Nb" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/noticeboard/directional/north,
-/obj/item/photo/old{
-	pixel_x = 5;
-	pixel_y = 25;
-	name = "photo of marines";
-	desc = "Remember your roots."
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"Ne" = (
-/obj/machinery/iv_drip/feeding_tube,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"Nl" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"Nq" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 5
-	},
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/item/food/meat/slab/pig,
-/obj/item/food/meat/slab/pig,
-/obj/item/food/meat/slab/pig,
-/obj/item/food/meat/slab/mouse,
-/obj/item/food/meat/slab/mouse,
-/obj/item/food/meat/slab/mouse,
-/obj/item/food/meat/slab/mouse,
-/obj/item/food/meat/slab/meatproduct,
-/obj/item/food/meat/slab/meatproduct,
-/obj/item/food/meat/slab/meatproduct,
-/obj/item/food/meat/slab/meatproduct,
-/obj/item/food/meat/slab/meatproduct,
-/obj/item/food/meat/slab/killertomato,
-/obj/item/food/meat/slab/killertomato,
-/obj/item/food/meat/slab/killertomato,
-/obj/item/food/meat/slab/killertomato,
-/obj/item/food/meat/steak,
-/obj/item/food/meat/steak,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/machinery/light/floor{
-	brightness = 7.5;
-	pixel_x = -16;
-	pixel_y = -16
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured,
-/area/misc/condo)
-"NF" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/obj/structure/railing{
-	color = "#36373a"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/shuttle/exploration/equipmentrail1,
-/area/misc/condo)
-"NG" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"NH" = (
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 2
-	},
-/obj/machinery/light/floor{
-	brightness = 7.5;
-	pixel_x = 16;
-	pixel_y = -16
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"NN" = (
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"NW" = (
+"Yi" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 9
 	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 9
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"NY" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Oa" = (
-/obj/item/trash/candy{
-	pixel_x = 10;
-	pixel_y = -3
-	},
-/obj/item/food/chocolatebar{
-	pixel_x = -4;
-	pixel_y = 9
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"Og" = (
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/siding/dark,
-/obj/structure/decorative{
-	icon = 'modular_skyrat/modules/advanced_shuttles/icons/computer.dmi';
-	icon_state = "computer_left";
-	density = 1;
-	anchored = 1
-	},
-/obj/structure/decorative{
-	icon_state = "wallmount";
-	pixel_y = 31;
-	icon = 'icons/obj/science/circuits.dmi';
-	dir = 8;
-	anchored = 1;
-	name = "wallmount"
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Oi" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/machinery/light/floor{
-	pixel_x = 0;
-	pixel_y = -16
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/misc/condo)
-"Op" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 6
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/misc/condo)
-"OD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side{
-	dir = 1
-	},
-/area/misc/condo)
-"OF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"OG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
-/area/misc/condo)
-"OT" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/structure/decorative{
-	icon_state = "intercom";
-	pixel_y = 31;
-	icon = 'icons/obj/machines/wallmounts.dmi';
-	base_icon_state = "tile_half";
-	dir = 8;
-	anchored = 1;
-	name = "Intercom";
-	desc = "An older model version of a standard intercom system."
-	},
-/obj/item/trash/tray,
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"OZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"Pg" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"PG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/structure/decorative{
-	icon_state = "intercom";
-	pixel_y = 31;
-	icon = 'icons/obj/machines/wallmounts.dmi';
-	base_icon_state = "tile_half";
-	dir = 8;
-	anchored = 1;
-	name = "Intercom";
-	desc = "An older model version of a standard intercom system."
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"PL" = (
-/obj/machinery/iv_drip/feeding_tube,
-/turf/open/floor/iron/shuttle/exploration/textured_flat,
-/area/misc/condo)
-"PQ" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"PV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/shuttle/exploration/side{
-	dir = 1
-	},
-/area/misc/condo)
-"PX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"Qc" = (
-/obj/structure/chair/sofa/corp/right,
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"Qn" = (
-/obj/structure/chair/sofa/corp,
-/obj/item/food/pizzaslice/margherita,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"Qq" = (
-/obj/item/storage/toolbox/syndicate,
-/obj/machinery/power/port_gen/pacman/super,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"Qv" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 5
-	},
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/turf/open/floor/iron/small,
-/area/misc/condo)
-"Qw" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 4
-	},
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/turf/open/floor/iron/small,
-/area/misc/condo)
-"Qx" = (
-/obj/item/trash/boritos{
-	pixel_x = 12;
-	pixel_y = -13
-	},
-/obj/item/trash/candy/twink_bar{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/obj/item/trash/energybar{
-	pixel_x = 17;
-	pixel_y = 17
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"QA" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark/corner,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"QD" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/trimline/dark,
-/turf/open/floor/iron/shuttle/exploration/doubleside,
-/area/misc/condo)
-"QP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/railing{
-	color = "#36373a";
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -9
-	},
-/obj/structure/railing{
-	color = "#36373a";
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -16
-	},
-/obj/structure/railing{
-	color = "#36373a";
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/structure/railing{
-	color = "#36373a";
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -23
-	},
-/turf/open/floor/plating,
-/area/misc/condo)
-"QU" = (
-/obj/structure/bed/maint{
-	pixel_x = 13;
-	pixel_y = -1
-	},
-/obj/item/restraints/handcuffs{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"Rc" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Re" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
-/area/misc/condo)
-"Rf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"Rh" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/half{
-	dir = 1
-	},
-/area/misc/condo)
-"Rt" = (
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	color = "#5d341f";
-	dir = 8;
-	use_holiday_colors = 0
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"RE" = (
-/obj/machinery/iv_drip/feeding_tube,
-/turf/open/floor/hay,
-/area/misc/condo)
-"RJ" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/biogenerator/foodricator,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"RK" = (
-/obj/effect/turf_decal/siding/dark/corner,
-/obj/effect/turf_decal/stripes/red/corner{
-	dir = 4
-	},
-/obj/structure/sign/warning/radiation/directional/south,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"RN" = (
-/obj/item/reagent_containers/cup/bottle/succubus_milk{
-	pixel_x = -11;
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 5
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"RP" = (
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
-	dir = 1
-	},
-/area/misc/condo)
-"Sd" = (
-/obj/item/skillchip/brainwashing{
-	pixel_x = 6;
-	pixel_y = -5
-	},
-/obj/item/skillchip/brainwashing{
-	pixel_x = -11;
-	pixel_y = 5
-	},
-/obj/item/skillchip/brainwashing{
-	pixel_x = 4;
-	pixel_y = 17
-	},
-/obj/item/disk/surgery/brainwashing{
-	pixel_x = -11;
-	pixel_y = -10
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/misc/condo)
-"Sl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/railing{
-	color = "#36373a";
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -9
-	},
-/obj/structure/railing{
-	color = "#36373a";
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -16
-	},
-/obj/structure/railing{
-	color = "#36373a";
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -30
-	},
-/obj/structure/railing{
-	color = "#36373a";
-	dir = 1;
-	pixel_x = 0;
-	pixel_y = -23
-	},
-/turf/open/floor/plating,
-/area/misc/condo)
-"Sy" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/item/plate{
-	pixel_x = -2;
-	pixel_y = 0
-	},
-/obj/item/plate{
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/item/plate{
-	pixel_x = -3;
-	pixel_y = 4
-	},
-/obj/item/plate{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"SD" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"SF" = (
-/obj/item/reagent_containers/cup/bottle/succubus_milk{
-	pixel_x = -5;
-	pixel_y = -6
-	},
-/obj/item/reagent_containers/cup/bottle/succubus_milk{
-	pixel_x = 10;
-	pixel_y = 6
-	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/hay,
-/area/misc/condo)
-"SJ" = (
-/obj/machinery/griddle/frontier_tabletop,
-/obj/structure/table/reinforced/plastitaniumglass,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"SL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
-	dir = 4
-	},
-/area/misc/condo)
-"Ta" = (
-/obj/structure/rack,
-/obj/item/mop/advanced,
-/obj/item/storage/bag/trash,
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Tl" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/dresser,
-/obj/item/sign/flag/syndicate{
-	pixel_x = 1;
-	pixel_y = 13
-	},
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"Tn" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/structure/cable,
-/obj/effect/turf_decal/siding/dark/corner,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"Tz" = (
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/bot,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"TN" = (
-/obj/effect/turf_decal/siding/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
-	dir = 8
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/iron/half{
-	dir = 1
-	},
-/area/misc/condo)
-"TT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner/end{
-	dir = 8;
-	color = "#36373a";
-	pixel_x = 0;
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	color = "#59595a";
-	dir = 8
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"TY" = (
-/obj/structure/gs13_fluff/brokenhose/scraps3,
-/turf/open/floor/hay,
-/area/misc/condo)
-"TZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/misc/condo)
-"Ue" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/dark/corner,
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"Uf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_red/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/turf/open/floor/iron/shuttle/exploration/side,
-/area/misc/condo)
-"Ut" = (
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/light{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding{
-	dir = 10
-	},
-/turf/open/floor/iron/white/diagonal,
-/area/misc/condo)
-"UA" = (
-/obj/item/radio,
-/turf/open/misc/asteroid/airless,
-/area/misc/condo)
-"UF" = (
-/obj/machinery/chem_dispenser/drinks/fullupgrade{
-	dir = 1
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"UI" = (
-/obj/item/clothing/mask/ballgag{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/food/cake/chocolate{
-	pixel_x = 4;
-	pixel_y = 19
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"UM" = (
-/obj/structure/closet/crate/secure/weapon,
-/obj/item/clothing/glasses/hud/health/night,
-/obj/item/gun/energy/fatoray,
-/obj/item/gun/energy/laser/alter_ray/gainrate,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/item/melee/baton/stunsword,
-/obj/item/melee/baton/stunsword,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"UO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/misc/condo)
-"UP" = (
-/obj/structure/sign/warning/secure_area/directional/north,
-/turf/open/space/basic,
-/area/misc/condo)
-"US" = (
-/obj/structure/cable,
-/obj/item/shell/bot{
-	name = "skyrat Sector server";
-	desc = "There's a sticky note on the side. It says 'Todo: Fix Serenity Station Crash Issues'";
-	anchored = 1;
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/misc/condo)
-"UZ" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/obj/structure/decorative{
-	icon = 'modular_skyrat/modules/advanced_shuttles/icons/computer.dmi';
-	icon_state = "computer_right";
-	anchored = 1
-	},
-/obj/structure/decorative{
-	icon_state = "intercom";
-	pixel_y = 31;
-	icon = 'icons/obj/machines/wallmounts.dmi';
-	base_icon_state = "tile_half";
-	dir = 8;
-	anchored = 1;
-	name = "Intercom";
-	desc = "An older model version of a standard intercom system."
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Va" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/machinery/vending/dinnerware{
-	free = 1
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"Vg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Vk" = (
-/obj/structure/rack/shelf,
-/obj/item/trash/syndi_cakes,
-/obj/item/trash/syndi_cakes,
-/obj/item/food/chips,
-/obj/item/food/chips,
-/obj/item/food/cornchips,
-/obj/item/food/cornchips,
-/obj/item/food/candy,
-/obj/item/food/candy,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Vx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/machinery/space_heater/wall_mounted/directional/north{
-	cell = /obj/item/stock_parts/power_store/cell/high;
-	pixel_y = -30
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"VA" = (
-/obj/structure/sign/warning/radiation{
-	pixel_y = -31
-	},
-/obj/structure/cable,
-/obj/item/shell/server{
-	name = "skyrat Sector server";
-	desc = "On the side you see a small LCD saying 'CONGRATULATIONS ITS BEEN 0 DAYS SINCE A UNIT TEST FAILED! A NEW RECORD!'";
-	anchored = 1;
-	pixel_x = -11;
-	pixel_y = 1
-	},
-/obj/structure/fluff/bus/passable/seat{
-	icon = 'icons/obj/machines/telecomms.dmi';
-	icon_state = "blackbox_b";
-	density = 1;
-	pixel_y = 0;
-	uses_integrity = 0;
-	name = "Copium Mining Server";
-	desc = "400TB of various tears and crashouts from maintainers and contributors alike. We're not sure how you got this many, but it's probably best not to ask.";
-	pixel_x = 12
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating,
-/area/misc/condo)
-"VE" = (
-/turf/closed/mineral/random,
-/area/misc/condo)
-"VF" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/siding/dark,
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"VI" = (
-/obj/machinery/door/airlock/hatch,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"VO" = (
-/obj/item/trash/can{
-	pixel_x = 11;
-	pixel_y = 12
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	color = "#5d341f";
-	dir = 2
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"VR" = (
-/obj/structure/cable,
-/turf/open/floor/pod/dark,
-/area/misc/condo)
-"VU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner/end{
-	dir = 4;
-	color = "#36373a"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/dark,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half{
-	alpha = 255;
-	color = "#59595a";
-	dir = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/misc/condo)
-"Wd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/turf/open/floor/iron/shuttle/exploration/doubleside,
-/area/misc/condo)
-"Wj" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark,
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"Wl" = (
-/obj/machinery/door/airlock/hatch,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"Wn" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"Ws" = (
-/obj/structure/chair/sofa/corp/left,
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"Wv" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 5
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 5
-	},
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"Wx" = (
-/obj/item/storage/bag/plants,
-/obj/effect/turf_decal/siding/dark/end,
-/obj/effect/turf_decal/trimline/dark_green/end,
-/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
-	dir = 8
-	},
-/turf/open/floor/iron/half{
-	dir = 1
-	},
-/area/misc/condo)
-"WB" = (
-/obj/item/trash/fleet_ration,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"WC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/shuttle/exploration/side{
-	dir = 1
-	},
-/area/misc/condo)
-"WM" = (
-/obj/structure/rack/shelf,
-/obj/item/storage/medkit/brute{
-	pixel_x = 0;
-	pixel_y = -2
-	},
-/obj/item/storage/medkit/fire{
-	pixel_x = 0;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"Xg" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 8
-	},
-/obj/structure/chair/sofa/bench{
-	dir = 4
-	},
-/obj/effect/overlay/water,
-/obj/effect/overlay/water/top,
-/turf/open/floor/iron/small,
-/area/misc/condo)
-"Xj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/obj/item/food/grown/lipofruit,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/misc/condo)
-"Xl" = (
-/obj/item/trash/boritos,
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"Xy" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/vending/mealdor{
-	free = 1
-	},
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/turf/open/floor/wood/tile,
-/area/misc/condo)
-"XT" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 5
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 5
-	},
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy"
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/structure/sign/flag/syndicate/directional/south,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"XX" = (
-/obj/machinery/button/door{
-	id = "feederden_cell1";
-	name = "Cell 1 Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_y = 32;
-	pixel_x = -8
-	},
-/obj/machinery/button/door{
-	id = "feederden_cell2";
-	name = "Cell 2 Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_y = 32;
-	pixel_x = 8
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 2
-	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
-/obj/machinery/light/floor{
-	brightness = 7.5;
-	pixel_x = 16;
-	pixel_y = -16
-	},
-/obj/effect/turf_decal/siding/dark/corner{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side,
-/area/misc/condo)
-"Yd" = (
-/obj/structure/sign/poster/contraband/corn_oil,
-/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
-/area/misc/condo)
-"Ye" = (
-/obj/effect/turf_decal/siding{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/light/end,
-/obj/structure/sink/directional/north,
-/obj/structure/mirror/directional/south,
-/obj/structure/decorative{
-	icon_state = "drain";
-	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
-	base_icon_state = "drain";
-	dir = 8;
-	name = "drain";
-	anchored = 1;
-	pixel_x = 0;
-	pixel_y = 11
-	},
-/turf/open/floor/iron/white/small,
-/area/misc/condo)
-"Yh" = (
-/turf/closed/indestructible/hoteldoor{
-	icon_state = "closed";
-	icon = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/external/external.dmi'
-	},
-/area/misc/condo)
-"Yk" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/iron/dark/smooth_large,
-/area/misc/condo)
-"Yp" = (
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 10
-	},
-/obj/structure/chair/sofa/bench/right{
+/obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
 /obj/effect/overlay/water,
@@ -5125,1810 +5092,1876 @@
 /obj/structure/marker_beacon/cerulean,
 /turf/open/floor/iron/small,
 /area/misc/condo)
-"Yr" = (
-/obj/machinery/vending/hotdog{
-	onstation = 0;
-	onstation_override = 1;
-	all_products_free = 1
+"Yn" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
 	},
-/turf/open/floor/iron/shuttle/exploration/textured_flat,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/item/trash/pistachios,
+/turf/open/floor/wood/tile,
 /area/misc/condo)
-"Yx" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 2;
-	name = "landing marker";
-	picked_color = "Burgundy"
+"Ys" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/book/manual/chef_recipes{
+	pixel_x = -8;
+	pixel_y = 3
 	},
-/obj/machinery/porta_turret/syndicate/fattening,
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"Yy" = (
+/obj/machinery/space_heater,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/structure/decorative{
+	icon = 'icons/obj/tram/tram_controllers.dmi';
+	icon_state = "rectifier";
+	anchored = 1;
+	name = "powerbox";
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"YF" = (
+/obj/item/construction/plumbing{
+	pixel_x = 3;
+	pixel_y = -18
+	},
+/obj/item/circuitboard/machine/power/adipoelectric_generator{
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/item/circuitboard/machine/adipoelectric_transformer{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/dim/directional/west,
 /turf/open/floor/plating,
 /area/misc/condo)
-"YB" = (
+"YJ" = (
+/obj/machinery/biogenerator,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"YR" = (
+/obj/item/trash/can,
+/obj/structure/sign/poster/contraband/eat/directional/east,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"YT" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/structure/filingcabinet,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper/fluff/ruins/feeder_den/report3,
+/obj/item/paper/fluff/ruins/feeder_den/report2,
+/obj/item/paper/fluff/ruins/feeder_den/report1,
+/obj/structure/fluff/paper/stack{
+	pixel_x = -14;
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/structure/sign/flag/syndicate/directional/south,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Zh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_red/line,
-/obj/effect/turf_decal/trimline/dark_red/corner{
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+/obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
-/turf/open/floor/mineral/plastitanium,
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_green/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
 /area/misc/condo)
-"YH" = (
+"Zi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/dark,
 /obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 4
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 2
 	},
-/obj/effect/turf_decal/trimline/dark_red/corner{
-	dir = 8
-	},
 /turf/open/floor/mineral/plastitanium,
 /area/misc/condo)
-"YJ" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
+"Zn" = (
+/obj/item/book/manual/blubbery_bartender{
+	pixel_y = -4;
+	pixel_x = -4
 	},
-/turf/open/floor/carpet/red,
-/area/misc/condo)
-"YR" = (
-/obj/structure/closet/secure_closet/freezer/kitchen/all_access,
-/obj/item/storage/fancy/egg_box,
-/obj/item/storage/fancy/egg_box,
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"YS" = (
-/obj/machinery/vending/fatty_items,
-/turf/open/floor/iron/shuttle/exploration/textured_flat,
-/area/misc/condo)
-"YX" = (
-/obj/machinery/seed_extractor,
-/obj/effect/turf_decal/siding/dark/corner{
+/obj/item/book/manual/fatty_chems{
+	pixel_y = -8;
+	pixel_x = -8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/shuttle/exploration,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/corner,
+/obj/effect/turf_decal/trimline/dark/corner,
+/obj/effect/turf_decal/trimline/dark/corner,
+/obj/structure/decorative{
+	icon = 'icons/obj/tram/tram_controllers.dmi';
+	icon_state = "tram-controller";
+	anchored = 1;
+	name = "powerbox";
+	pixel_x = -30
+	},
+/turf/open/floor/iron/white/textured,
 /area/misc/condo)
-"Zh" = (
+"ZA" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wideplating_new/dark{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/dark{
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium/red,
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner,
 /area/misc/condo)
-"Zi" = (
-/obj/machinery/suit_storage_unit/industrial/syndicatecontractor,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/pod/dark,
+"ZF" = (
+/obj/structure/curtain,
+/turf/open/floor/iron/freezer,
 /area/misc/condo)
-"Zk" = (
-/obj/item/trash/fatoray_scrap1,
-/turf/open/misc/asteroid/airless,
-/area/misc/condo)
-"Zo" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/processor{
-	pixel_x = 1;
-	pixel_y = 8
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/misc/condo)
-"ZK" = (
+"ZT" = (
+/obj/structure/chair/sofa/corp/left,
 /obj/machinery/light/directional/north,
 /turf/open/floor/carpet/red,
 /area/misc/condo)
-"ZX" = (
-/turf/closed/indestructible/hotelwall{
-	color = "#000000"
-	},
-/area/misc/condo)
-"ZZ" = (
-/obj/effect/turf_decal/tile/blue/diagonal_edge,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/siding/wideplating/light/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wideplating/light/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white/diagonal,
+"ZW" = (
+/obj/item/radio,
+/turf/open/misc/asteroid/airless,
 /area/misc/condo)
 
 (1,1,1) = {"
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
 "}
 (2,1,1) = {"
-ZX
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-zX
-ri
-VE
-VE
-VE
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+zB
+oO
+Ni
+Ni
+Ni
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (3,1,1) = {"
-ZX
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-VE
-VE
-om
-om
-om
-om
-zX
-Gz
-zX
-zX
-CP
-oj
-zX
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+Ni
+Ni
+fn
+fn
+fn
+fn
+zB
+Ts
+zB
+zB
+EY
+eQ
+zB
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (4,1,1) = {"
-ZX
-nP
-nP
-nP
-nP
-nP
-nP
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-lP
-zX
-zX
-zX
-zX
-zX
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+rp
+rp
+rp
+rp
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+xp
+zB
+zB
+zB
+zB
+zB
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (5,1,1) = {"
-ZX
-nP
-nP
-nP
-nP
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-Gz
-zX
-VE
-VE
-VE
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+rp
+rp
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ts
+zB
+Ni
+Ni
+Ni
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (6,1,1) = {"
-ZX
-nP
-nP
-nP
-VE
-VE
-VE
-VE
-fq
-cb
-cb
-cb
-cb
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-VE
-VE
-VE
-nP
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+rp
+Ni
+Ni
+Ni
+Ni
+rB
+VD
+VD
+VD
+VD
+rB
+rB
+rB
+rB
+rB
+rB
+rB
+rB
+rB
+Ni
+Ni
+Ni
+rp
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (7,1,1) = {"
-ZX
-nP
-nP
-VE
-VE
-VE
-VE
-oj
-cb
-OT
-Ko
-Fd
-sc
-cb
-Fe
-ED
-fq
-rO
-da
-Xg
-Yp
-fq
-VE
-VE
-VE
-VE
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+Ni
+Ni
+Ni
+Ni
+eQ
+VD
+oZ
+hB
+Rb
+Dl
+VD
+UZ
+qT
+rB
+Dt
+Yi
+Wq
+VI
+rB
+Ni
+Ni
+Ni
+Ni
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (8,1,1) = {"
-ZX
-nP
-nP
-VE
-VE
-VE
-eN
-zX
-cb
-Xl
-Ag
-aX
-dP
-Sl
-HY
-Ji
-fq
-vz
-Qv
-Qw
-DW
-fq
-fq
-fq
-VE
-VE
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+Ni
+Ni
+Ni
+Nc
+zB
+VD
+yi
+mL
+OB
+nS
+Nd
+ZA
+EC
+rB
+FR
+lL
+Fl
+Gf
+rB
+rB
+rB
+Ni
+Ni
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (9,1,1) = {"
-ZX
-nP
-VE
-VE
-VE
-VE
-zX
-nd
-Em
-mR
-WB
-Pg
-gE
-ni
-qS
-Kf
-aR
-Ms
-kx
-Bx
-kl
-aR
-co
-fq
-VE
-VE
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+Ni
+Ni
+Ni
+Ni
+zB
+SD
+iO
+oz
+hK
+mz
+BG
+Ya
+gU
+go
+ZF
+RM
+IK
+WA
+IU
+ZF
+Ah
+rB
+Ni
+Ni
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (10,1,1) = {"
-ZX
-nP
-VE
-VE
-VE
-VE
-ri
-zX
-cb
-Ne
-yV
-Pg
-cM
-MO
-Cc
-pm
-aR
-jk
-BY
-EF
-bK
-aR
-Dy
-fq
-VE
-VE
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+Ni
+Ni
+Ni
+Ni
+oO
+zB
+VD
+fv
+At
+kW
+Sc
+Nj
+xJ
+Ek
+ZF
+gk
+qG
+fO
+LP
+ZF
+jR
+rB
+Ni
+Ni
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (11,1,1) = {"
-ZX
-nP
-nP
-VE
-VE
-VE
-oj
-UA
-fq
-cb
+SC
+rp
+rp
+Ni
+Ni
+Ni
+eQ
+ZW
+rB
+VD
+cM
+VD
+VD
+rB
+zF
 Cl
-cb
-cb
-fq
-XX
-dv
-fq
-cb
-cb
-fq
-fq
-cb
-cb
-cb
-fq
-VE
-nP
-nP
-nP
-nP
-nP
-ZX
+rB
+VD
+VD
+rB
+rB
+VD
+VD
+VD
+rB
+Ni
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (12,1,1) = {"
-ZX
-nP
-nP
-Gz
-VE
-VE
-VE
-lW
-fq
-RE
-SF
-LH
-is
-Sl
-pt
-Hb
-cb
-tY
-xQ
-Yr
-fq
-zS
-mf
-Bo
-cb
-VE
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+Ts
+Ni
+Ni
+Ni
+Wh
+rB
+MI
+iq
+Vg
+cn
+Nd
+Qj
+ii
+VD
+fy
+Gj
+yP
+rB
+sy
+YF
+ju
+VD
+Ni
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (13,1,1) = {"
-ZX
-nP
-nP
-zX
-zX
-VE
-VE
-VE
-fq
-HP
-TY
-zD
-Wd
-vT
-rt
-Es
-cb
-fr
-QD
-EU
-cb
-td
-KU
-DN
-cb
-VE
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+zB
+zB
+Ni
+Ni
+Ni
+rB
+CB
+JO
+bh
+nD
+Mw
+ea
+Uk
+VD
+Uu
+Ta
+Dh
+VD
+qx
+sT
+DQ
+VD
+Ni
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (14,1,1) = {"
-ZX
-nP
-nP
-oj
-zX
-zX
-zX
-VE
-fq
-xd
-lq
-vq
-aD
-QP
-vc
-Es
-cb
-PL
-kU
-YS
-cb
-UO
-Xj
-xv
-cb
-VE
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+eQ
+zB
+zB
+zB
+Ni
+rB
+vw
+gh
+Ea
+nn
+td
+Ql
+Uk
+VD
+kE
+oB
+QK
+VD
+Fd
+JF
+jO
+VD
+Ni
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (15,1,1) = {"
-ZX
-nP
-nP
-VE
-zX
-fq
-fq
-fq
-fq
-fq
-cb
-cb
-cb
-fq
-Av
-cp
-cb
-fq
-Hh
-fq
-fq
-cb
-MK
-cb
-fq
-VE
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+Ni
+zB
+rB
+rB
+rB
+rB
+rB
+VD
+VD
+VD
+rB
+by
+Dw
+VD
+rB
+ab
+rB
+rB
+VD
+wH
+VD
+rB
+Ni
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (16,1,1) = {"
-ZX
-nP
-nP
-VE
-oj
-fq
-Tl
-rH
-fq
-gZ
-pp
-bX
-iw
-fq
-tb
-tE
-cb
-Vk
-rl
-NY
-Rc
-tw
-qC
-UM
-cb
-VE
-VE
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+Ni
+eQ
+rB
+xc
+XY
+rB
+Iv
+gQ
+KC
+WV
+rB
+pa
+HN
+VD
+Nv
+Oe
+WL
+Lr
+AQ
+zI
+Bp
+VD
+Ni
+Ni
+rp
+rp
+rp
+rp
+SC
 "}
 (17,1,1) = {"
-ZX
-nP
-nP
-VE
-VE
-fq
-Nb
-cd
-Yk
-dj
-cY
-hd
-ui
-If
-Ie
-TT
-cb
-bt
-ib
-Zh
-wc
-ib
-yS
-IO
-cb
-VE
-VE
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+Ni
+Ni
+rB
+gY
+UA
+ro
+La
+Tj
+Co
+MZ
+aG
+FU
+rR
+VD
+KR
+vH
+sl
+qV
+vH
+Ln
+ww
+VD
+Ni
+Ni
+rp
+rp
+rp
+rp
+SC
 "}
 (18,1,1) = {"
-ZX
-nP
-nP
-VE
-VE
-fq
-yE
-pi
-fq
-Og
-rg
-qB
-ty
-tr
-NH
-mU
-cb
-px
-GV
-hW
-ox
-Oi
-Cf
-WM
-cb
-VE
-VE
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+Ni
+Ni
+rB
+Xa
+Ar
+rB
+aQ
+fN
+uA
+QP
+XO
+yR
+oY
+VD
+gR
+UH
+rv
+HI
+MM
+ph
+lB
+VD
+Ni
+Ni
+rp
+rp
+rp
+rp
+SC
 "}
 (19,1,1) = {"
-ZX
-nP
-nP
-VE
-Gz
-fq
-fq
-fq
-fq
-UZ
-gz
-DJ
-Jj
-fq
-Ke
-ts
-cb
-MU
-zh
-Bk
-Au
-zh
-Op
-LB
-cb
-VE
-VE
-VE
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+Ni
+Ts
+rB
+rB
+rB
+rB
+QB
+ce
+aZ
+YT
+rB
+Af
+yZ
+VD
+yN
+CM
+MF
+Rg
+CM
+SH
+PI
+VD
+Ni
+Ni
+Ni
+rp
+rp
+rp
+SC
 "}
 (20,1,1) = {"
-ZX
-nP
-nP
-zX
-zX
-oj
-VE
-VE
-fq
-fq
-Sl
-Sl
-fq
-fq
-JD
-OZ
-cb
-HA
-Vg
-Cz
-ie
-sG
-Ta
-Cr
-cb
-VE
-VE
-VE
-VE
-nP
-nP
-ZX
+SC
+rp
+rp
+zB
+zB
+eQ
+Ni
+Ni
+rB
+rB
+Nd
+Nd
+rB
+rB
+Is
+Ci
+VD
+pR
+SF
+oo
+wd
+of
+TV
+yx
+VD
+Ni
+Ni
+Ni
+Ni
+rp
+rp
+SC
 "}
 (21,1,1) = {"
-ZX
-nP
-nP
-zX
-lP
-Gz
-VE
-VE
-fq
-Cm
-Im
-Im
-bR
-Va
-JD
-vM
-fq
-cb
-Yk
-iX
-cb
-fq
-fq
-fq
-cb
-VE
-Yx
-lP
-VE
-nP
-nP
-ZX
+SC
+rp
+rp
+zB
+xp
+Ts
+Ni
+Ni
+rB
+xl
+fP
+fP
+oe
+uY
+Is
+Jk
+rB
+VD
+fb
+vQ
+VD
+rB
+rB
+rB
+VD
+Ni
+NW
+xp
+Ni
+rp
+rp
+SC
 "}
 (22,1,1) = {"
-ZX
-nP
-VE
-zX
-oj
-cb
-fq
-cb
-fq
-PQ
-Mr
-wE
-wE
-Jp
-JD
-OZ
-Re
-vw
-Cu
+SC
+rp
+Ni
+zB
+eQ
+VD
+rB
+VD
+rB
+fF
 JI
-tX
-Yk
-uy
-sy
-cb
-VE
-lP
-zX
-nP
-nP
-nP
-ZX
+qy
+qy
+lZ
+Is
+Ci
+rB
+hg
+hJ
+mR
+ba
+FN
+Zn
+Bk
+VD
+Ni
+xp
+zB
+rp
+rp
+rp
+SC
 "}
 (23,1,1) = {"
-ZX
-VE
-VE
-lP
-zX
-Sl
-aW
-Ab
-KN
-wo
-sa
-sa
-sa
-Wj
-nW
-YH
-pM
-zz
-vV
-Ig
-mj
-cb
-Nq
-sq
-cb
-VE
-om
-nP
-nP
-nP
-nP
-ZX
+SC
+Ni
+Ni
+xp
+zB
+Nd
+rc
+oX
+iM
+Ob
+Rp
+Rp
+Rp
+IA
+mO
+am
+sp
+tn
+sN
+bI
+YJ
+VD
+xW
+JW
+VD
+Ni
+fn
+rp
+rp
+rp
+rp
+SC
 "}
 (24,1,1) = {"
-ZX
-VE
-VE
-zX
-Sl
-Sl
-kR
-hD
-zR
-lf
-uZ
-cb
-Qc
-FV
-vF
-ts
-Yd
-no
-mB
-wy
-SJ
-cb
-cb
-cb
-fq
-UP
-om
-nP
-nP
-nP
-nP
-ZX
+SC
+Ni
+Ni
+zB
+Nd
+Nd
+sg
+Yn
+gI
+Kl
+EW
+VD
+lM
+XQ
+nY
+yZ
+LG
+bo
+Ys
+Se
+ef
+VD
+VD
+VD
+rB
+EQ
+fn
+rp
+rp
+rp
+rp
+SC
 "}
 (25,1,1) = {"
-ZX
-VE
-CP
-zX
-Sl
-xr
-yX
-Hn
-uA
-lf
-UF
-bD
-Hx
-FV
-JD
-OZ
-Sl
-iN
-tv
-VF
-wb
-cb
-mb
-mb
-zZ
-nP
-om
-nP
-nP
-nP
-nP
-ZX
+SC
+Ni
+EY
+zB
+Nd
+FP
+Xw
+Jh
+xj
+Kl
+vb
+uT
+Ly
+XQ
+Is
+Ci
+Nd
+vA
+kH
+Rm
+Ra
+VD
+PR
+PR
+Lo
+rp
+fn
+rp
+rp
+rp
+rp
+SC
 "}
 (26,1,1) = {"
-ZX
-zX
-zX
-zX
-Sl
-Qn
-jG
-bd
-uA
-VO
-nt
-bD
-Dz
-FV
-JD
-OZ
-Sl
-Kb
-NN
-VF
-RJ
-Sl
-mb
-mb
-kN
-nP
-om
-nP
-nP
-nP
-nP
-ZX
+SC
+zB
+zB
+zB
+Nd
+CN
+QW
+iL
+xj
+tk
+If
+uT
+eq
+XQ
+Is
+Ci
+Nd
+WI
+hT
+Rm
+DW
+Nd
+PR
+PR
+Ap
+rp
+fn
+rp
+rp
+rp
+rp
+SC
 "}
 (27,1,1) = {"
-ZX
-VE
-lP
-zX
-Sl
-hJ
-YJ
-mD
-AJ
-lf
-op
-bD
+SC
+Ni
+xp
+zB
+Nd
+Cu
+eo
+NG
+mb
+Kl
+Vu
+uT
+GO
+XQ
+Is
+Ci
+Nd
+BN
+kH
+Rm
+Db
+VD
+PR
+PR
+Lo
+rp
 fn
-FV
-JD
-OZ
-Sl
-xs
-tv
-VF
-iO
-cb
-mb
-mb
-zZ
-nP
-om
-nP
-nP
-nP
-nP
-ZX
+rp
+rp
+rp
+rp
+SC
 "}
 (28,1,1) = {"
-ZX
-VE
-Gz
-zX
-Sl
-Sl
-Ca
-Oa
-Sy
-lf
-jv
-cb
-Ws
-jj
-lE
-wB
-ca
-IC
-NG
-Nl
-if
-cb
-Yh
-Yh
-fq
-UP
-om
-nP
-VE
-VE
-nP
-ZX
+SC
+Ni
+Ts
+zB
+Nd
+Nd
+Ih
+Cs
+pA
+Kl
+El
+VD
+ZT
+kA
+jn
+zM
+cT
+Hd
+FE
+yh
+Tc
+VD
+NI
+NI
+rB
+EQ
+fn
+rp
+Ni
+Ni
+rp
+SC
 "}
 (29,1,1) = {"
-ZX
-zX
-zX
-zX
-Jx
-Sl
-RN
-UI
-JZ
-Wn
-tN
-tN
-tN
-aq
-eT
-ny
-pM
-Wv
-yr
-ep
-hC
-cb
-yj
-TZ
-cb
-VE
-lP
-zX
-VE
-VE
-VE
-ZX
+SC
+zB
+zB
+zB
+UF
+Nd
+dp
+rt
+pS
+wR
+fR
+fR
+fR
+io
+mC
+Zi
+oD
+bT
+ld
+Of
+AW
+VD
+PS
+wz
+VD
+Ni
+xp
+zB
+Ni
+Ni
+Ni
+SC
 "}
 (30,1,1) = {"
-ZX
-VE
-VE
-lP
-zX
-cb
-fq
-fq
-fq
-Xy
-wE
-wE
-Rt
-Jp
-JD
-as
-fq
-dd
-YR
-jB
-Zo
-cb
-fO
-dL
-cb
-VE
-Lx
-lP
-zX
-VE
-VE
-ZX
+SC
+Ni
+Ni
+xp
+zB
+VD
+rB
+rB
+rB
+UJ
+qy
+qy
+qy
+lZ
+Is
+Nf
+rB
+Gc
+cC
+AJ
+Fv
+VD
+OK
+NS
+VD
+Ni
+rU
+xp
+zB
+Ni
+Ni
+SC
 "}
 (31,1,1) = {"
-ZX
-nP
-VE
-VE
-CP
-ri
-VE
-VE
-fq
-ke
-hr
-ce
-ce
-qz
-JD
-Vx
-fq
-cb
-cb
-cb
-cb
-fq
-rQ
-rQ
-cb
-VE
-lP
-ri
-zX
-lP
-VE
-ZX
+SC
+rp
+Ni
+Ni
+EY
+oO
+Ni
+Ni
+rB
+aq
+Hj
+Th
+Th
+Fg
+Is
+SY
+rB
+VD
+VD
+VD
+VD
+rB
+VA
+VA
+VD
+Ni
+xp
+oO
+zB
+xp
+Ni
+SC
 "}
 (32,1,1) = {"
-ZX
-nP
-nP
-zX
-zX
-oj
-VE
-VE
-fq
-fq
-fq
-NW
-lG
-Gu
-JD
-as
-cb
-Tz
-ja
-Zi
-cb
-py
-pe
-wP
-cb
-VE
-oj
-lP
-CP
-zX
-VE
-ZX
+SC
+rp
+rp
+zB
+zB
+eQ
+Ni
+Ni
+rB
+rB
+rB
+RS
+cz
+RO
+Is
+Em
+VD
+Je
+lv
+BX
+VD
+wh
+wS
+Fi
+VD
+Ni
+eQ
+xp
+EY
+zB
+Ni
+SC
 "}
 (33,1,1) = {"
-ZX
-nP
-nP
-nP
-om
-zX
-VE
-VE
-VE
-VE
-fq
-PG
-fB
-FW
-AY
-cy
-cb
-ff
-pY
-AC
-cb
-EK
-pY
-RK
-cb
-fq
-fq
-fq
-oj
-zX
-ri
-ZX
+SC
+rp
+rp
+rp
+fn
+zB
+Ni
+Ni
+Ni
+Ni
+rB
+kZ
+WE
+BY
+BR
+gn
+VD
+vL
+Qg
+NR
+VD
+oW
+Qg
+Ub
+VD
+rB
+rB
+rB
+eQ
+zB
+oO
+SC
 "}
 (34,1,1) = {"
-ZX
-nP
-nP
-nP
-om
-nP
-nP
-VE
-VE
-fq
-fq
-Yk
-fq
-fq
-SD
-YB
-jM
-qP
-mk
-mk
-Fp
-KL
-gy
-dx
-Wl
-NF
-Bd
-fq
-zX
-zX
-ri
-ZX
+SC
+rp
+rp
+rp
+fn
+rp
+rp
+Ni
+Ni
+rB
+rB
+bF
+rB
+rB
+KE
+mT
+qO
+BS
+Lf
+Lf
+zz
+aw
+TH
+Qk
+Qf
+Lv
+Nh
+rB
+zB
+zB
+oO
+SC
 "}
 (35,1,1) = {"
-ZX
-nP
-nP
-nP
-om
-nP
-nP
-VE
-VE
-fq
-Ll
-bJ
-XT
-fq
-hH
-VU
-cb
-vi
-PX
-fk
-IF
-ou
-OF
-dr
-cb
-Ap
-VA
-fq
-zX
-zX
-zX
-ZX
+SC
+rp
+rp
+rp
+fn
+rp
+rp
+Ni
+Ni
+rB
+yq
+xQ
+bx
+rB
+Xs
+Nq
+VD
+Yy
+Rn
+bU
+WN
+en
+cp
+Vw
+VD
+hz
+jQ
+rB
+zB
+zB
+zB
+SC
 "}
 (36,1,1) = {"
-ZX
-ri
-Gz
-VE
-om
-nP
-nP
-VE
-VE
-fq
-cs
-BX
-jr
-fq
-qD
-Kz
-cb
-QA
-Rf
-na
-Iy
-Tn
-mF
-Qq
-cb
-up
-US
-fq
-zX
-Gz
-nP
-ZX
+SC
+oO
+Ts
+Ni
+fn
+rp
+rp
+Ni
+Ni
+rB
+eG
+Pe
+GJ
+rB
+Tt
+Ru
+VD
+iv
+gq
+Nt
+qH
+uc
+Lx
+UE
+VD
+LS
+nM
+rB
+zB
+Ts
+rp
+SC
 "}
 (37,1,1) = {"
-ZX
-Gz
-Yx
-VE
-fq
-fq
-fq
-fq
-fq
-fq
-cb
-cb
-cb
-fq
-CN
-SL
-cb
-cb
-ME
-cb
-fq
-cb
-VI
-cb
-fq
-fq
-fq
-fq
-VE
-zX
-nP
-ZX
+SC
+Ts
+NW
+Ni
+rB
+rB
+rB
+rB
+rB
+rB
+VD
+VD
+VD
+rB
+lN
+Ve
+VD
+VD
+Ec
+VD
+rB
+VD
+Do
+VD
+rB
+rB
+rB
+rB
+Ni
+zB
+rp
+SC
 "}
 (38,1,1) = {"
-ZX
-Gz
-VE
-VE
-fq
-ez
-nf
-Ue
-gj
-se
-sf
-oV
-kt
-Sl
-oO
-Es
-cb
-iM
-jP
-CC
-cb
-Hv
-JU
-YX
-Fx
-Fx
-Fx
-fq
-VE
-VE
-nP
-ZX
+SC
+Ts
+Ni
+Ni
+rB
+VC
+dR
+qm
+gy
+hb
+mI
+hw
+DX
+Nd
+zi
+Uk
+VD
+rk
+yJ
+XT
+VD
+fL
+XS
+mG
+Hr
+Hr
+Hr
+rB
+Ni
+Ni
+rp
+SC
 "}
 (39,1,1) = {"
-ZX
-nP
-VE
-VE
-fq
-FG
-oU
-eX
-xa
-sO
-me
-VR
-st
-Ee
-PV
-Es
-cb
-jA
-kK
-Df
-Yk
+SC
+rp
+Ni
+Ni
+rB
+DA
+Pp
+ys
+Xx
+KQ
+jK
+jm
+Tz
+lr
+sW
+Uk
+VD
 ct
-vn
-vG
-Rh
-TN
-Wx
-fq
-VE
-VE
-nP
-ZX
+KG
+Sz
+Ha
+re
+Zh
+Kw
+HC
+Bf
+SK
+rB
+Ni
+Ni
+rp
+SC
 "}
 (40,1,1) = {"
-ZX
-nP
-nP
-VE
-fq
-su
-EO
-hQ
-oL
-xR
-aS
-Sd
-jY
-QP
-Dl
-OD
-cb
-oM
-IB
-yY
-cb
-dK
-kc
-iF
-Fx
-Fx
-Fx
-fq
-VE
-VE
-nP
-ZX
+SC
+rp
+rp
+Ni
+rB
+cW
+CZ
+UU
+xP
+ll
+ug
+jU
+NB
+td
+Vd
+Ep
+VD
+dW
+UB
+Ja
+VD
+gC
+iw
+bV
+Hr
+Hr
+Hr
+rB
+Ni
+Ni
+rp
+SC
 "}
 (41,1,1) = {"
-ZX
-nP
-nP
-nP
-fq
-fq
-fq
-fq
-fq
-cb
-Cl
-cb
-cb
-fq
-rP
-IM
-fq
-cb
-cb
-fq
-fq
-cb
-gj
-Fm
-OG
-fq
-fq
-fq
-VE
-VE
-nP
-ZX
+SC
+rp
+rp
+rp
+rB
+rB
+rB
+rB
+rB
+VD
+cM
+VD
+VD
+rB
+cx
+SZ
+rB
+VD
+VD
+rB
+rB
+VD
+gy
+ec
+AK
+rB
+rB
+rB
+Ni
+Ni
+rp
+SC
 "}
 (42,1,1) = {"
-ZX
-nP
-nP
-nP
-om
-nP
-VE
-VE
-cb
-BO
-GM
-Qx
-gE
-gx
-AB
-qb
-aR
-xu
-cC
-cb
-VE
-lP
-Gz
-Bh
-rN
-VE
-VE
-VE
-VE
-nP
-nP
-ZX
+SC
+rp
+rp
+rp
+fn
+rp
+Ni
+Ni
+VD
+rV
+Wk
+dG
+BG
+nE
+nC
+EF
+ZF
+lK
+MJ
+VD
+Ni
+xp
+Ts
+RJ
+hF
+Ni
+Ni
+Ni
+Ni
+rp
+rp
+SC
 "}
 (43,1,1) = {"
-ZX
-nP
-nP
-nP
-om
-nP
-VE
-VE
-cb
-QU
-yo
-Pg
-qJ
-rk
-WC
-Uf
-aR
-ZZ
-Ut
-cb
-Lx
-lP
-zX
-oj
-zX
-zX
-oj
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+rp
+fn
+rp
+Ni
+Ni
+VD
+dI
+KB
+mz
+hp
+bq
+oG
+rs
+ZF
+oE
+tI
+VD
+rU
+xp
+zB
+eQ
+zB
+zB
+eQ
+rp
+rp
+rp
+rp
+SC
 "}
 (44,1,1) = {"
-ZX
-nP
-nP
-nP
-om
-VE
-VE
-VE
-cb
-ZK
-nk
-Pg
-sn
-Sl
-rJ
-RP
-fq
-aR
-aR
-fq
-Zk
-zX
-zX
-zX
-zX
-zX
-zX
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+rp
+fn
+Ni
+Ni
+Ni
+VD
+jj
+tO
+mz
+Mc
+Nd
+xM
+yY
+rB
+ZF
+ZF
+rB
+mS
+zB
+zB
+zB
+zB
+zB
+zB
+rp
+rp
+rp
+rp
+SC
 "}
 (45,1,1) = {"
-ZX
-nP
-nP
-nP
-VE
-VE
-VE
-VE
-cb
-Ne
-qd
-ET
-ht
-cb
-Fe
-ED
-fq
-zf
-Ye
-fq
-oj
-zX
-zX
-zX
-Gz
-VE
-VE
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+rp
+Ni
+Ni
+Ni
+Ni
+VD
+fv
+YR
+vu
+LH
+VD
+UZ
+qT
+rB
+od
+rh
+rB
+eQ
+zB
+zB
+zB
+Ts
+Ni
+Ni
+rp
+rp
+rp
+rp
+SC
 "}
 (46,1,1) = {"
-ZX
-nP
-nP
-nP
-VE
-VE
-VE
-VE
-fq
-cb
-cb
-cb
-cb
-fq
-fq
-fq
-fq
-fq
-fq
-fq
-VE
-Gz
-zX
-zX
-CP
-VE
-VE
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+rp
+Ni
+Ni
+Ni
+Ni
+rB
+VD
+VD
+VD
+VD
+rB
+rB
+rB
+rB
+rB
+rB
+rB
+Ni
+Ts
+zB
+zB
+EY
+Ni
+Ni
+rp
+rp
+rp
+rp
+SC
 "}
 (47,1,1) = {"
-ZX
-nP
-nP
-nP
-nP
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-VE
-nP
-nP
-VE
-VE
-VE
-VE
-VE
-zX
-zX
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+rp
+rp
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+rp
+rp
+Ni
+Ni
+Ni
+Ni
+Ni
+zB
+zB
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (48,1,1) = {"
-ZX
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-VE
-VE
-VE
-VE
-VE
-VE
-nP
-nP
-nP
-nP
-nP
-nP
-VE
-VE
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-nP
-ZX
+SC
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+Ni
+Ni
+Ni
+Ni
+Ni
+Ni
+rp
+rp
+rp
+rp
+rp
+rp
+Ni
+Ni
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+rp
+SC
 "}
 (49,1,1) = {"
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
-ZX
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+SC
 "}

--- a/modular_gs/code/modules/condos/_maps/feeder_den.dmm
+++ b/modular_gs/code/modules/condos/_maps/feeder_den.dmm
@@ -1,0 +1,6934 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aq" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"as" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"aD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/reagentgrinder{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/clothing/glasses/science{
+	pixel_y = 11;
+	pixel_x = 8
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/box/beakers/bluespace{
+	pixel_x = 8;
+	pixel_y = -1
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleside,
+/area/misc/condo)
+"aR" = (
+/obj/structure/curtain,
+/turf/open/floor/iron/freezer,
+/area/misc/condo)
+"aS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/galbanium,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"aW" = (
+/obj/item/reagent_containers/cup/soda_cans/dr_gibb{
+	pixel_x = -1;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/cup/soda_cans/cola{
+	pixel_x = 12;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/table/reinforced/plastitaniumglass{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"aX" = (
+/obj/vehicle/ridden/wheelchair,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"bd" = (
+/obj/structure/scale,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"bt" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/syndicate,
+/obj/item/multitool,
+/obj/item/clothing/head/utility/welding,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"bD" = (
+/obj/structure/window/fulltile,
+/obj/structure/hedge,
+/turf/open/floor/plating,
+/area/misc/condo)
+"bJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/circuit/red,
+/area/misc/condo)
+"bK" = (
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/machinery/shower/directional/west,
+/obj/structure/decorative{
+	icon_state = "drain";
+	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
+	base_icon_state = "drain";
+	dir = 8;
+	name = "drain";
+	anchored = 1;
+	pixel_x = -1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"bR" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/box/beakers/bluespace,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"bX" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/box/handcuffs{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"ca" = (
+/obj/machinery/computer/security/telescreen/entertainment,
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
+/area/misc/condo)
+"cb" = (
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/misc/condo)
+"cd" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"ce" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"co" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/light/end{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/west{
+	pixel_x = 0;
+	pixel_y = 13
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"cp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
+	dir = 1
+	},
+/area/misc/condo)
+"cs" = (
+/obj/structure/safe,
+/obj/item/toy/plush/rouny,
+/obj/item/stack/arcadeticket{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/item/clothing/head/hair_tie/plastic_beads,
+/turf/open/floor/circuit/red,
+/area/misc/condo)
+"ct" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/half{
+	dir = 1
+	},
+/area/misc/condo)
+"cy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"cC" = (
+/obj/machinery/shower/directional/east,
+/obj/structure/decorative{
+	icon_state = "drain";
+	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
+	base_icon_state = "drain";
+	dir = 8;
+	name = "drain";
+	anchored = 1;
+	pixel_x = -1
+	},
+/obj/effect/turf_decal/siding/wideplating/light/end{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/light/end{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"cM" = (
+/obj/item/trash/candy,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"cY" = (
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/trimline/dark/corner,
+/obj/effect/turf_decal/trimline/dark/corner,
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"da" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/structure/chair/sofa/bench/left{
+	dir = 4
+	},
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/marker_beacon/cerulean,
+/turf/open/floor/iron/small,
+/area/misc/condo)
+"dd" = (
+/obj/machinery/smartfridge/food,
+/obj/item/food/taco,
+/obj/item/food/nigiri_sushi,
+/obj/item/food/spaghetti/pastatomato,
+/obj/item/reagent_containers/cup/glass/bottle/small{
+	pixel_x = -11;
+	pixel_y = 19
+	},
+/obj/item/reagent_containers/cup/glass/bottle/small{
+	pixel_x = -2;
+	pixel_y = 19
+	},
+/obj/item/reagent_containers/cup/glass/bottle{
+	pixel_x = 8;
+	pixel_y = 22
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"dj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"dr" = (
+/obj/machinery/power/port_gen/pacman/super,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"dv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side{
+	dir = 1
+	},
+/area/misc/condo)
+"dx" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"dK" = (
+/obj/machinery/chem_dispenser/mutagensaltpeter,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/shuttle/exploration,
+/area/misc/condo)
+"dL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"dP" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"ep" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"ez" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"eN" = (
+/obj/item/screwdriver,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"eT" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"eX" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"ff" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/stripes/red/corner,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"fk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"fn" = (
+/obj/structure/chair/sofa/corp,
+/obj/item/gun/energy/laser/alter_ray/noloss{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"fq" = (
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
+/area/misc/condo)
+"fr" = (
+/obj/structure/closet/wardrobe/mixed,
+/turf/open/floor/iron/shuttle/exploration/textured_flat,
+/area/misc/condo)
+"fB" = (
+/obj/machinery/cryopod/quiet{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"fO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"gj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/misc/condo)
+"gx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cell 4"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"gy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"gz" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/paper/fluff/ruins/feeder_den/report4{
+	pixel_x = 9;
+	pixel_y = 14
+	},
+/obj/item/pen/red{
+	pixel_x = 2;
+	pixel_y = 14
+	},
+/obj/item/storage/fancy/cigarettes/cigpack_syndicate{
+	pixel_x = -7;
+	pixel_y = -9
+	},
+/obj/item/lighter{
+	pixel_x = 3;
+	pixel_y = -12
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/item/flashlight/lamp{
+	pixel_x = -6;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"gE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"gZ" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/structure/rack/shelf,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/item/melee/baton/telescopic{
+	pixel_x = -3;
+	pixel_y = 10
+	},
+/obj/item/melee/baton/telescopic{
+	pixel_x = 11;
+	pixel_y = 10
+	},
+/obj/item/melee/baton/telescopic{
+	pixel_x = 4;
+	pixel_y = 10
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"hd" = (
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"hr" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/chair/beanbag/red{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"ht" = (
+/obj/vehicle/ridden/wheelchair,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"hC" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/reagentgrinder,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -9;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -9;
+	pixel_y = -1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"hD" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/item/trash/pistachios,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"hH" = (
+/obj/structure/cable,
+/obj/structure/railing/corner/end{
+	dir = 4;
+	color = "#36373a";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#59595a";
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"hJ" = (
+/obj/structure/chair/sofa/corp/corner,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"hQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/meter,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"hW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
+/obj/machinery/light/floor{
+	pixel_x = 0;
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/trimline/dark{
+	pixel_x = 0;
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/trimline/dark{
+	pixel_x = 0;
+	pixel_y = 16
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"ib" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"ie" = (
+/obj/structure/rack/shelf,
+/obj/item/vending_refill/mealdor,
+/obj/item/vending_refill/mealdor,
+/obj/item/vending_refill/mealdor,
+/obj/item/vending_refill/mealdor,
+/obj/item/vending_refill/cola,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"if" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"is" = (
+/obj/machinery/vending/mealdor{
+	free = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/iron/shuttle/exploration/doubleside,
+/area/misc/condo)
+"iw" = (
+/obj/machinery/vending/fatty_items,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"iF" = (
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/shuttle/exploration,
+/area/misc/condo)
+"iM" = (
+/obj/machinery/atmospherics/components/tank/air/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/plumbing/synthesizer/water_synth,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"iN" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/box/hecu_rations{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/storage/box/hecu_rations{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/storage/box/hecu_rations{
+	pixel_x = 1;
+	pixel_y = 2
+	},
+/obj/item/storage/box/hecu_rations{
+	pixel_x = 5;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"iO" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/microwave/frontier_printed,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"iX" = (
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"ja" = (
+/obj/machinery/power/apc{
+	name = "Base Power Controller";
+	pixel_x = -28
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"jj" = (
+/obj/item/trash/candy{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 1;
+	use_holiday_colors = 0
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"jk" = (
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"jr" = (
+/obj/structure/filingcabinet,
+/obj/item/folder/syndicate/mining,
+/obj/item/folder/syndicate/red,
+/turf/open/floor/circuit/red,
+/area/misc/condo)
+"jv" = (
+/obj/machinery/vending/boozeomat/syndicate,
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"jA" = (
+/obj/structure/rack/shelf,
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/mineral/titanium/fifty{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"jB" = (
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"jG" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/fancy/large_donut_box{
+	pixel_x = 0;
+	pixel_y = 2
+	},
+/obj/item/storage/fancy/large_donut_box{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/item/storage/fancy/large_donut_box{
+	pixel_x = 0;
+	pixel_y = 14
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"jM" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"jP" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"jY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/implantchair/brainwash,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"kc" = (
+/obj/machinery/vending/hydronutrients,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/shuttle/exploration,
+/area/misc/condo)
+"ke" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/machinery/vending/gato{
+	free = 1
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"kl" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"kt" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"kx" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/obj/item/kitchen/spoon/soup_ladle{
+	name = "sauna ladle";
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"kK" = (
+/obj/machinery/light/floor,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"kN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"kR" = (
+/obj/item/food/meat/bacon{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"kU" = (
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 8
+	},
+/area/misc/condo)
+"lf" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 2
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"lq" = (
+/obj/structure/reagent_dispensers/servingdish{
+	name = "nutrislop dish";
+	desc = "Syndicate's finest, sloppest."
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/hay,
+/area/misc/condo)
+"lE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"lG" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"lP" = (
+/obj/structure/flora/bush/jungle/a/style_3,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"lW" = (
+/obj/structure/flora/bush/jungle,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"mb" = (
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"me" = (
+/obj/structure/cable,
+/obj/machinery/light/floor,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"mf" = (
+/obj/item/construction/plumbing{
+	pixel_x = 3;
+	pixel_y = -18
+	},
+/obj/item/circuitboard/machine/power/adipoelectric_generator{
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/item/circuitboard/machine/adipoelectric_transformer{
+	pixel_x = -5;
+	pixel_y = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/dim/directional/west,
+/turf/open/floor/plating,
+/area/misc/condo)
+"mj" = (
+/obj/machinery/biogenerator,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"mk" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"mB" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/book/manual/chef_recipes{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"mD" = (
+/obj/item/plate/large,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"mF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"mR" = (
+/obj/structure/bed/maint,
+/obj/item/clothing/neck/human_petcollar/calorite{
+	pixel_x = 3;
+	pixel_y = -6
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"mU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"na" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"nd" = (
+/obj/item/paper/fluff/ruins/feeder_den/hidden,
+/turf/open/floor/plating,
+/area/misc/condo)
+"nf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"ni" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cell 1"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"nk" = (
+/obj/item/trash/tray,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"no" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/knife/butcher{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = 11;
+	pixel_y = -9
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"nt" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"ny" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"nP" = (
+/turf/open/space/basic,
+/area/misc/condo)
+"nW" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"oj" = (
+/obj/structure/flora/rock/pile,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"om" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/misc/condo)
+"op" = (
+/obj/item/storage/box/drinkingglasses{
+	pixel_y = 5;
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/cup/beaker/bluespace{
+	pixel_x = -17;
+	pixel_y = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"ou" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"ox" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets/donkpocketberry{
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"oL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/misc/condo)
+"oM" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/box,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"oO" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleside,
+/area/misc/condo)
+"oU" = (
+/obj/structure/scale,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"oV" = (
+/obj/structure/table/optable,
+/obj/item/storage/backpack/duffelbag/syndie/surgery{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"pe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"pi" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/item/bedsheet/syndie{
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/obj/structure/bed/pod{
+	pixel_x = 0;
+	pixel_y = 10
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"pm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/iron/shuttle/exploration/side,
+/area/misc/condo)
+"pp" = (
+/obj/structure/rack/shelf{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/item/melee/baton/security/cattleprod/loaded{
+	pixel_x = -4;
+	pixel_y = -1
+	},
+/obj/item/melee/baton/security/cattleprod/loaded{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"pt" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side,
+/area/misc/condo)
+"px" = (
+/obj/item/grenade/chem_grenade/fatmix{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/holosign_creator/hardlight_wheelchair{
+	pixel_x = 14;
+	pixel_y = 9
+	},
+/obj/item/holosign_creator/hardlight_wheelchair{
+	pixel_x = 14;
+	pixel_y = 2
+	},
+/obj/item/holosign_creator/hardlight_wheelchair{
+	pixel_x = 14;
+	pixel_y = -5
+	},
+/obj/machinery/vending/wallmed/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"py" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/structure/closet/firecloset/full,
+/obj/effect/turf_decal/box,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"pM" = (
+/obj/machinery/door/poddoor/shutters/window/preopen,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"pY" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"qb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/shuttle/exploration/side,
+/area/misc/condo)
+"qd" = (
+/obj/item/trash/can,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"qz" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"qB" = (
+/obj/structure/fluff/paper/stack{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"qC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"qD" = (
+/obj/structure/cable,
+/obj/structure/decorative/fluff{
+	icon = 'icons/turf/floors.dmi';
+	base_icon_state = "stairs-old";
+	icon_state = "stairs-m";
+	anchored = 1;
+	pixel_y = 0;
+	name = "staircase";
+	desc = "A small step for the humanity, and so is for you.";
+	dir = 8;
+	color = "#474747"
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"qJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"qP" = (
+/obj/structure/disposalpipe/junction/flip,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"qS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/side{
+	dir = 1
+	},
+/area/misc/condo)
+"rg" = (
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/structure/chair/beanbag/red,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"ri" = (
+/obj/structure/flora/bush/grassy,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"rk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cell 4"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"rl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner/end{
+	dir = 8;
+	color = "#36373a"
+	},
+/obj/structure/railing/corner/end{
+	dir = 8;
+	color = "#36373a";
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"rt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/side{
+	dir = 1
+	},
+/area/misc/condo)
+"rH" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/safe/abovetilefloor,
+/obj/item/stack/sheet/mineral/calorite/ten,
+/obj/item/stack/sheet/mineral/calorite/ten,
+/obj/item/stack/sheet/mineral/calorite/ten,
+/obj/structure/sign/flag/syndicate/directional/south,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"rJ" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
+	dir = 8
+	},
+/area/misc/condo)
+"rN" = (
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/misc/condo)
+"rO" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light/end{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/end{
+	dir = 8
+	},
+/obj/structure/towel_bin{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/structure/rack/shelf,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"rP" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side,
+/area/misc/condo)
+"rQ" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"sa" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 4;
+	use_holiday_colors = 0
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"sc" = (
+/obj/item/plate{
+	pixel_x = 12;
+	pixel_y = -1
+	},
+/obj/item/plate{
+	pixel_x = 17;
+	pixel_y = 4
+	},
+/obj/item/plate{
+	pixel_x = 18;
+	pixel_y = 7
+	},
+/obj/item/plate{
+	pixel_x = 39;
+	pixel_y = -7
+	},
+/obj/item/plate{
+	pixel_x = 17;
+	pixel_y = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"se" = (
+/obj/structure/cable,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"sf" = (
+/obj/structure/cable,
+/obj/item/storage/toolbox/syndicate{
+	pixel_x = 20;
+	pixel_y = 9
+	},
+/obj/item/organ/cyberimp/chest/nutriment/turbo{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/organ/cyberimp/chest/nutriment/turbo{
+	pixel_x = 10;
+	pixel_y = -13
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"sn" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"sq" = (
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/structure/rack/shelf,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/item/storage/box/ingredients/wildcard,
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
+/area/misc/condo)
+"st" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"su" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"sy" = (
+/obj/structure/closet/crate{
+	name = "Pizza Storage"
+	},
+/obj/item/pizzabox/infinite,
+/obj/item/pizzabox/infinite,
+/obj/item/pizzabox/infinite,
+/obj/item/pizzabox/infinite,
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white/textured,
+/area/misc/condo)
+"sG" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/effect/spawner/random/bedsheet/any,
+/obj/effect/spawner/random/bedsheet/any,
+/obj/effect/spawner/random/bedsheet/any,
+/obj/effect/spawner/random/bedsheet/any,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"sO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/item/holosign_creator/atmos,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"tb" = (
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1
+	},
+/obj/structure/decorative/fluff{
+	icon = 'icons/turf/floors.dmi';
+	base_icon_state = "stairs-old";
+	icon_state = "stairs-m";
+	anchored = 1;
+	pixel_y = 0;
+	name = "staircase";
+	desc = "A small step for the humanity, and so is for you.";
+	dir = 4;
+	color = "#474747"
+	},
+/obj/structure/fake_stairs/directional/south{
+	icon_state = "stairs-old";
+	icon = 'icons/turf/floors.dmi';
+	color = "#555555";
+	dir = 8;
+	pixel_y = 1
+	},
+/obj/structure/fake_stairs/directional/south{
+	icon_state = "stairs-old";
+	icon = 'icons/turf/floors.dmi';
+	color = "#555555";
+	dir = 8;
+	pixel_y = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"td" = (
+/obj/structure/gs13_fluff/brokenhose/scraps3{
+	pixel_x = -2;
+	pixel_y = -11
+	},
+/obj/structure/reagent_dispensers/cooking_oil/cream,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/misc/condo)
+"tr" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Office"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"ts" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"tv" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/trimline/dark,
+/obj/effect/turf_decal/trimline/dark,
+/obj/effect/turf_decal/trimline/dark,
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"tw" = (
+/obj/machinery/food_cart,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"ty" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"tE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing{
+	color = "#36373a"
+	},
+/obj/structure/decorative/fluff{
+	icon = 'icons/turf/floors.dmi';
+	base_icon_state = "stairs-old";
+	icon_state = "stairs-m";
+	anchored = 1;
+	pixel_y = 0;
+	name = "staircase";
+	desc = "A small step for the humanity, and so is for you.";
+	dir = 4;
+	color = "#474747"
+	},
+/obj/structure/fake_stairs/directional/south{
+	icon_state = "stairs-old";
+	icon = 'icons/turf/floors.dmi';
+	color = "#555555";
+	dir = 8;
+	pixel_y = 1
+	},
+/obj/structure/fake_stairs/directional/south{
+	icon_state = "stairs-old";
+	icon = 'icons/turf/floors.dmi';
+	color = "#555555";
+	dir = 8;
+	pixel_y = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"tN" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 8;
+	use_holiday_colors = 0
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"tX" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"tY" = (
+/obj/machinery/vending/clothing,
+/turf/open/floor/iron/shuttle/exploration/textured_flat,
+/area/misc/condo)
+"ui" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"up" = (
+/obj/structure/decorative{
+	anchored = 1;
+	name = "wiring";
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	icon_state = "apc2";
+	pixel_y = 23;
+	uses_integrity = 0;
+	pixel_x = 2
+	},
+/obj/structure/railing{
+	color = "#36373a"
+	},
+/obj/structure/decorative{
+	icon_state = "projector";
+	pixel_y = 5;
+	icon = 'modular_skyrat/modules/wargame_projectors/icons/projectors_and_holograms.dmi';
+	base_icon_state = "projector";
+	dir = 8;
+	pixel_x = 2;
+	anchored = 1;
+	name = "hologram projector"
+	},
+/obj/structure/decorative{
+	icon_state = "cell_charger_packed";
+	pixel_y = 9;
+	icon = 'modular_skyrat/modules/colony_fabricator/icons/packed_machines.dmi';
+	base_icon_state = "recharger";
+	dir = 8;
+	anchored = 1;
+	name = "glorpus";
+	pixel_x = 3
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/shuttle/exploration/equipmentrail3,
+/area/misc/condo)
+"uy" = (
+/obj/item/book/manual/blubbery_bartender{
+	pixel_y = -4;
+	pixel_x = -4
+	},
+/obj/item/book/manual/fatty_chems{
+	pixel_y = -8;
+	pixel_x = -8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark/corner,
+/obj/effect/turf_decal/trimline/dark/corner,
+/obj/effect/turf_decal/trimline/dark/corner,
+/obj/structure/decorative{
+	icon = 'icons/obj/tram/tram_controllers.dmi';
+	icon_state = "tram-controller";
+	anchored = 1;
+	name = "powerbox";
+	pixel_x = -30
+	},
+/obj/machinery/light/small/dim/directional/west,
+/turf/open/floor/iron/white/textured,
+/area/misc/condo)
+"uA" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 1;
+	use_holiday_colors = 0
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"uZ" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
+	dir = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"vc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleside,
+/area/misc/condo)
+"vi" = (
+/obj/machinery/space_heater,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/structure/decorative{
+	icon = 'icons/obj/tram/tram_controllers.dmi';
+	icon_state = "rectifier";
+	anchored = 1;
+	name = "powerbox";
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"vn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_green/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/misc/condo)
+"vq" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/railing/wooden_fence,
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 2
+	},
+/obj/item/clothing/neck/human_petcollar/locked/cow{
+	pixel_x = 0;
+	pixel_y = 16
+	},
+/obj/machinery/iv_drip/gs13/plumbing_milker,
+/turf/open/floor/hay,
+/area/misc/condo)
+"vw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/machinery/vending/dinnerware{
+	free = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"vz" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/structure/railing/corner/end{
+	dir = 8;
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/obj/structure/railing/corner/end{
+	dir = 4
+	},
+/obj/structure/decorative/fluff{
+	icon = 'icons/turf/floors.dmi';
+	base_icon_state = "stairs-old";
+	icon_state = "stairs-old";
+	anchored = 1;
+	pixel_y = -24;
+	name = "staircase";
+	desc = "A small step for the humanity, and so is for you.";
+	pixel_x = 0
+	},
+/obj/structure/decorative/fluff{
+	icon = 'icons/turf/decals.dmi';
+	icon_state = "warningline";
+	anchored = 1;
+	name = "warning line"
+	},
+/obj/structure/decorative/fluff{
+	icon = 'icons/turf/decals.dmi';
+	icon_state = "warningline_white";
+	anchored = 1;
+	name = "warning line"
+	},
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = 31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system."
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"vF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"vG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/half{
+	dir = 1
+	},
+/area/misc/condo)
+"vM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/machinery/space_heater/wall_mounted/directional/north{
+	cell = /obj/item/stock_parts/power_store/cell/high;
+	pixel_y = -30
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"vT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cell 2"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"vV" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"wb" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/chem_dispenser/frontier_appliance,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"wc" = (
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"wo" = (
+/obj/item/trash/boritos{
+	pixel_x = 18;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"wy" = (
+/obj/structure/sink/kitchen/directional/south,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"wB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"wE" = (
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"wP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"xa" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Cell 3"
+	},
+/obj/structure/fans/tiny/forcefield,
+/obj/structure/fans/tiny,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"xd" = (
+/obj/structure/reagent_dispensers/cooking_oil,
+/turf/open/floor/hay,
+/area/misc/condo)
+"xr" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"xs" = (
+/obj/machinery/deepfryer,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"xu" = (
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"xv" = (
+/obj/structure/gs13_fluff/brokenhose{
+	pixel_x = -1;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/misc/condo)
+"xQ" = (
+/turf/open/floor/iron/shuttle/exploration/uside{
+	dir = 4
+	},
+/area/misc/condo)
+"xR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 1;
+	name = "O2 To Pure"
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/lipoifium,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"yj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy";
+	pixel_x = 17;
+	pixel_y = -16
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"yo" = (
+/obj/item/trash/vendor_trash/lizard_bag,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"yr" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"yE" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/item/bedsheet/syndie,
+/obj/structure/bed/pod,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"yS" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"yV" = (
+/obj/structure/reagent_dispensers/servingdish{
+	name = "nutrislop dish";
+	desc = "Syndicate's finest, sloppest."
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"yX" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"yY" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/storage/box/disks_plantgene,
+/obj/item/storage/box/disks_plantgene,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"zf" = (
+/obj/effect/turf_decal/siding/wideplating/light/end{
+	dir = 1
+	},
+/obj/structure/toilet,
+/obj/machinery/light/small/directional/east{
+	pixel_x = 0;
+	pixel_y = -11
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"zh" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"zz" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"zD" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/hay,
+/area/misc/condo)
+"zR" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"zS" = (
+/obj/machinery/iv_drip/gs13/plumbing_feeder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/misc/condo)
+"zX" = (
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"zZ" = (
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red,
+/turf/open/floor/plating,
+/area/misc/condo)
+"Ab" = (
+/obj/item/reagent_containers/cup/bottle/succubus_milk{
+	pixel_x = 7;
+	pixel_y = 14
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Ag" = (
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Ap" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/structure/railing{
+	color = "#36373a"
+	},
+/obj/item/training_toolbox{
+	name = "ambiguous toolbox";
+	icon_state = "coroner";
+	desc = "Don't cum on the servers.";
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/obj/item/screwdriver{
+	pixel_x = -1;
+	pixel_y = 13
+	},
+/obj/structure/decorative{
+	icon_state = "wallmount";
+	pixel_y = 31;
+	icon = 'icons/obj/science/circuits.dmi';
+	dir = 8;
+	anchored = 1;
+	name = "wallmount"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/shuttle/exploration/equipmentrail2,
+/area/misc/condo)
+"Au" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/box/donkpockets/donkpockethonk,
+/obj/item/storage/box/donkpockets/donkpocketpizza{
+	pixel_y = 4
+	},
+/obj/item/storage/box/donkpockets/donkpocketspicy{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Av" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
+	dir = 8
+	},
+/area/misc/condo)
+"AB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/side{
+	dir = 1
+	},
+/area/misc/condo)
+"AC" = (
+/obj/machinery/suit_storage_unit/industrial/syndicatecontractor,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"AJ" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 1;
+	use_holiday_colors = 0
+	},
+/obj/item/plate_shard{
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"AY" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Bd" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/power/rtg/debug,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/misc/condo)
+"Bh" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/misc/condo)
+"Bk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"Bo" = (
+/obj/machinery/iv_drip/gs13/plumbing_milker,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/misc/condo)
+"Bx" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	dir = 8
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"BO" = (
+/obj/structure/table,
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = 31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system."
+	},
+/obj/item/plate{
+	pixel_x = 0;
+	pixel_y = -1
+	},
+/obj/item/plate{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/item/plate{
+	pixel_x = -1;
+	pixel_y = 3
+	},
+/obj/item/plate{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/plate{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/obj/item/plate{
+	pixel_x = 2;
+	pixel_y = 9
+	},
+/obj/item/plate{
+	pixel_x = 0;
+	pixel_y = 12
+	},
+/obj/item/plate{
+	pixel_x = 1;
+	pixel_y = 14
+	},
+/obj/item/plate{
+	pixel_x = 1;
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"BX" = (
+/turf/open/floor/circuit/red,
+/area/misc/condo)
+"BY" = (
+/obj/machinery/shower/directional/west,
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/structure/decorative{
+	icon_state = "drain";
+	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
+	base_icon_state = "drain";
+	dir = 8;
+	name = "drain";
+	anchored = 1;
+	pixel_x = -1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"Ca" = (
+/obj/item/clothing/mask/leatherwhip,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Cc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/side{
+	dir = 1
+	},
+/area/misc/condo)
+"Cf" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark{
+	pixel_x = 0;
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/trimline/dark{
+	pixel_x = 0;
+	pixel_y = 16
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"Cl" = (
+/obj/machinery/computer/security/telescreen/entertainment,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/misc/condo)
+"Cm" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/reagent_dispensers/cooking_oil/cream/open,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Cr" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/box/beakers,
+/obj/item/reagent_containers/cup/soda_cans/air,
+/obj/item/reagent_containers/cup/soda_cans/beer,
+/obj/item/reagent_containers/cup/soda_cans/beer/rice,
+/obj/item/reagent_containers/cup/soda_cans/blood_tea,
+/obj/item/reagent_containers/cup/soda_cans/canned_laughter,
+/obj/item/reagent_containers/cup/soda_cans/cola,
+/obj/item/reagent_containers/cup/soda_cans/dr_gibb,
+/obj/item/reagent_containers/cup/soda_cans/fizzwiz,
+/obj/item/reagent_containers/cup/soda_cans/grey_bull,
+/obj/item/reagent_containers/cup/soda_cans/lemon_lime,
+/obj/item/reagent_containers/cup/soda_cans/melon_soda,
+/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
+/obj/item/reagent_containers/cup/soda_cans/pwr_game,
+/obj/item/reagent_containers/cup/soda_cans/shamblers,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Cu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Cz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"CC" = (
+/obj/machinery/autolathe/hacked,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"CN" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner,
+/area/misc/condo)
+"CP" = (
+/obj/structure/flora/rock,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"Df" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"Dl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/corner,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side,
+/area/misc/condo)
+"Dy" = (
+/obj/structure/sink/directional/west,
+/obj/structure/mirror/directional/east,
+/obj/effect/turf_decal/siding/wideplating/light/end{
+	dir = 4
+	},
+/obj/structure/decorative{
+	icon_state = "drain";
+	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
+	base_icon_state = "drain";
+	dir = 8;
+	name = "drain";
+	anchored = 1;
+	pixel_x = -16;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"Dz" = (
+/obj/structure/chair/sofa/corp,
+/obj/item/reagent_containers/cup/bowl,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"DJ" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/fluff/paper/stack{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"DN" = (
+/obj/structure/gs13_fluff/brokenhose/scraps1{
+	pixel_x = 4;
+	pixel_y = 1
+	},
+/obj/machinery/power/adipoelectric_transformer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/misc/condo)
+"DW" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/open/floor/iron/small,
+/area/misc/condo)
+"Ee" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cell 3"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"Em" = (
+/obj/structure/falsewall/plastitanium,
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating,
+/area/misc/condo)
+"Es" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleside,
+/area/misc/condo)
+"ED" = (
+/obj/machinery/vending/dorms,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"EF" = (
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/machinery/shower/directional/west,
+/obj/structure/decorative{
+	icon_state = "drain";
+	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
+	base_icon_state = "drain";
+	dir = 8;
+	name = "drain";
+	anchored = 1;
+	pixel_x = -1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"EK" = (
+/obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"EO" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"ET" = (
+/obj/structure/scale,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"EU" = (
+/obj/structure/reagent_dispensers/keg/lipoifier,
+/turf/open/floor/iron/shuttle/exploration/textured_flat,
+/area/misc/condo)
+"Fd" = (
+/obj/structure/scale,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Fe" = (
+/obj/machinery/vending/mealdor{
+	free = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"Fm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
+/area/misc/condo)
+"Fp" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"Fx" = (
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/iron/shuttle/exploration/equipmentrail2,
+/area/misc/condo)
+"FG" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"FV" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 1;
+	use_holiday_colors = 0
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"FW" = (
+/obj/machinery/cryopod/quiet{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/structure/decorative{
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	icon_state = "tram";
+	pixel_x = 28;
+	pixel_y = 11;
+	dir = 1;
+	name = "curtain button"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Gu" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Gz" = (
+/obj/structure/flora/bush/jungle/b/style_3,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"GM" = (
+/obj/structure/reagent_dispensers/servingdish{
+	name = "nutrislop dish";
+	desc = "Syndicate's finest, sloppest."
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"GV" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"Hb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side{
+	dir = 1
+	},
+/area/misc/condo)
+"Hh" = (
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1
+	},
+/obj/structure/railing{
+	color = "#36373a"
+	},
+/obj/structure/fake_stairs/directional/south{
+	icon_state = "stairs-old";
+	icon = 'icons/turf/floors.dmi';
+	color = "#555555";
+	dir = 8;
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"Hn" = (
+/obj/item/plate{
+	pixel_x = 8;
+	pixel_y = -4
+	},
+/obj/item/plate{
+	pixel_x = 9;
+	pixel_y = -2
+	},
+/obj/item/plate{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/obj/item/plate_shard{
+	pixel_x = -3;
+	pixel_y = -7
+	},
+/obj/item/plate_shard{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Hv" = (
+/obj/machinery/plantgenes{
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/shuttle/exploration,
+/area/misc/condo)
+"Hx" = (
+/obj/structure/chair/sofa/corp,
+/obj/item/trash/boritos{
+	pixel_x = 0;
+	pixel_y = -2
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"HA" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = -4
+	},
+/obj/item/storage/fancy/donut_box,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"HP" = (
+/obj/structure/chair/milking_machine,
+/turf/open/floor/hay,
+/area/misc/condo)
+"HY" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner,
+/area/misc/condo)
+"Ie" = (
+/obj/structure/railing/corner/end{
+	dir = 8;
+	color = "#36373a"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#59595a";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"If" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -9
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -16
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/misc/condo)
+"Ig" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"Im" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/iv_drip/feeding_tube,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Iy" = (
+/obj/structure/rack/shelf,
+/obj/item/stack/sheet/cardboard{
+	amount = 3
+	},
+/obj/item/stack/sheet/cardboard{
+	amount = 3
+	},
+/obj/item/stack/sheet/cardboard{
+	amount = 3
+	},
+/obj/item/stack/sheet/cardboard{
+	amount = 3
+	},
+/obj/item/stack/rods/twentyfive,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/item/storage/box/stockparts/deluxe,
+/obj/structure/cable,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"IB" = (
+/obj/item/bodybag/bluespace,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"IC" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/oven/range_frontier,
+/obj/item/reagent_containers/cup/soup_pot,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"IF" = (
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"IM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side{
+	dir = 1
+	},
+/area/misc/condo)
+"IO" = (
+/obj/structure/ore_box,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Ji" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
+	dir = 4
+	},
+/area/misc/condo)
+"Jj" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/structure/filingcabinet,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper,
+/obj/item/paper/fluff/ruins/feeder_den/report3,
+/obj/item/paper/fluff/ruins/feeder_den/report2,
+/obj/item/paper/fluff/ruins/feeder_den/report1,
+/obj/structure/fluff/paper/stack{
+	pixel_x = -14;
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/structure/sign/flag/syndicate/directional/south,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Jp" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Jx" = (
+/obj/structure/flora/bush/jungle/b/style_3,
+/obj/structure/flora/rock/pile,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"JD" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"JI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"JU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_green/line,
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner,
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/half,
+/area/misc/condo)
+"JZ" = (
+/obj/item/food/burger/greaseburger{
+	pixel_x = 1;
+	pixel_y = 14
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Kb" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/reagent_containers/condiment/enzyme{
+	pixel_x = 3;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/condiment/ketchup{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/plate{
+	pixel_x = -10;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"Ke" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Kf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/shuttle/exploration/side,
+/area/misc/condo)
+"Ko" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Kz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/decorative/fluff{
+	icon = 'icons/turf/floors.dmi';
+	base_icon_state = "stairs-old";
+	icon_state = "stairs-m";
+	anchored = 1;
+	pixel_y = 0;
+	name = "staircase";
+	desc = "A small step for the humanity, and so is for you.";
+	dir = 8;
+	color = "#474747"
+	},
+/obj/structure/railing{
+	color = "#36373a"
+	},
+/turf/open/floor/iron/shuttle/exploration/blanktile,
+/area/misc/condo)
+"KL" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"KN" = (
+/obj/item/trash/tray,
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"KU" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/trimline/dark,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/misc/condo)
+"Ll" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy"
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Lx" = (
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy"
+	},
+/obj/structure/lattice/catwalk,
+/obj/machinery/porta_turret/syndicate/fattening,
+/turf/open/floor/plating,
+/area/misc/condo)
+"LB" = (
+/obj/structure/rack/shelf,
+/obj/item/electropack/shockcollar,
+/obj/item/clothing/neck/petcollar,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs/cable/zipties,
+/obj/item/clothing/mask/ballgag,
+/obj/item/clothing/mask/ballgag,
+/obj/item/clothing/mask/ballgag/choking,
+/obj/item/clothing/mask/ballgag/choking,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"LH" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/railing/wooden_fence,
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 2
+	},
+/turf/open/floor/hay,
+/area/misc/condo)
+"Mr" = (
+/obj/structure/reagent_dispensers/keg/lipoifier,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Ms" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"ME" = (
+/obj/machinery/door/airlock/hatch,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"MK" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Junk Shed"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"MO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/public/glass{
+	name = "Cell 1"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"MU" = (
+/obj/machinery/recharger,
+/obj/item/implanter{
+	pixel_x = 9;
+	pixel_y = 15
+	},
+/obj/item/implanter{
+	pixel_x = 9;
+	pixel_y = 11
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Nb" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/noticeboard/directional/north,
+/obj/item/photo/old{
+	pixel_x = 5;
+	pixel_y = 25;
+	name = "photo of marines";
+	desc = "Remember your roots."
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Ne" = (
+/obj/machinery/iv_drip/feeding_tube,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Nl" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"Nq" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/item/food/meat/slab/pig,
+/obj/item/food/meat/slab/pig,
+/obj/item/food/meat/slab/pig,
+/obj/item/food/meat/slab/mouse,
+/obj/item/food/meat/slab/mouse,
+/obj/item/food/meat/slab/mouse,
+/obj/item/food/meat/slab/mouse,
+/obj/item/food/meat/slab/meatproduct,
+/obj/item/food/meat/slab/meatproduct,
+/obj/item/food/meat/slab/meatproduct,
+/obj/item/food/meat/slab/meatproduct,
+/obj/item/food/meat/slab/meatproduct,
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/meat/steak,
+/obj/item/food/meat/steak,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = -16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
+/area/misc/condo)
+"NF" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/structure/railing{
+	color = "#36373a"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/shuttle/exploration/equipmentrail1,
+/area/misc/condo)
+"NG" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"NH" = (
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"NN" = (
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"NW" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"NY" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Oa" = (
+/obj/item/trash/candy{
+	pixel_x = 10;
+	pixel_y = -3
+	},
+/obj/item/food/chocolatebar{
+	pixel_x = -4;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Og" = (
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
+/obj/structure/decorative{
+	icon = 'modular_skyrat/modules/advanced_shuttles/icons/computer.dmi';
+	icon_state = "computer_left";
+	density = 1;
+	anchored = 1
+	},
+/obj/structure/decorative{
+	icon_state = "wallmount";
+	pixel_y = 31;
+	icon = 'icons/obj/science/circuits.dmi';
+	dir = 8;
+	anchored = 1;
+	name = "wallmount"
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Oi" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/machinery/light/floor{
+	pixel_x = 0;
+	pixel_y = -16
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"Op" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 6
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"OD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side{
+	dir = 1
+	},
+/area/misc/condo)
+"OF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"OG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
+/area/misc/condo)
+"OT" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = 31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system."
+	},
+/obj/item/trash/tray,
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"OZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Pg" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"PG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = 31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system."
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"PL" = (
+/obj/machinery/iv_drip/feeding_tube,
+/turf/open/floor/iron/shuttle/exploration/textured_flat,
+/area/misc/condo)
+"PQ" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"PV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/shuttle/exploration/side{
+	dir = 1
+	},
+/area/misc/condo)
+"PX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/red/line{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"Qc" = (
+/obj/structure/chair/sofa/corp/right,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Qn" = (
+/obj/structure/chair/sofa/corp,
+/obj/item/food/pizzaslice/margherita,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Qq" = (
+/obj/item/storage/toolbox/syndicate,
+/obj/machinery/power/port_gen/pacman/super,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"Qv" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/open/floor/iron/small,
+/area/misc/condo)
+"Qw" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/open/floor/iron/small,
+/area/misc/condo)
+"Qx" = (
+/obj/item/trash/boritos{
+	pixel_x = 12;
+	pixel_y = -13
+	},
+/obj/item/trash/candy/twink_bar{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/trash/energybar{
+	pixel_x = 17;
+	pixel_y = 17
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"QA" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"QD" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/trimline/dark,
+/turf/open/floor/iron/shuttle/exploration/doubleside,
+/area/misc/condo)
+"QP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -9
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -16
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -23
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"QU" = (
+/obj/structure/bed/maint{
+	pixel_x = 13;
+	pixel_y = -1
+	},
+/obj/item/restraints/handcuffs{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Rc" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Re" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
+/area/misc/condo)
+"Rf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"Rh" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/half{
+	dir = 1
+	},
+/area/misc/condo)
+"Rt" = (
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 8;
+	use_holiday_colors = 0
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"RE" = (
+/obj/machinery/iv_drip/feeding_tube,
+/turf/open/floor/hay,
+/area/misc/condo)
+"RJ" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/biogenerator/foodricator,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"RK" = (
+/obj/effect/turf_decal/siding/dark/corner,
+/obj/effect/turf_decal/stripes/red/corner{
+	dir = 4
+	},
+/obj/structure/sign/warning/radiation/directional/south,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"RN" = (
+/obj/item/reagent_containers/cup/bottle/succubus_milk{
+	pixel_x = -11;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"RP" = (
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
+	dir = 1
+	},
+/area/misc/condo)
+"Sd" = (
+/obj/item/skillchip/brainwashing{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/item/skillchip/brainwashing{
+	pixel_x = -11;
+	pixel_y = 5
+	},
+/obj/item/skillchip/brainwashing{
+	pixel_x = 4;
+	pixel_y = 17
+	},
+/obj/item/disk/surgery/brainwashing{
+	pixel_x = -11;
+	pixel_y = -10
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/misc/condo)
+"Sl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -9
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -16
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -30
+	},
+/obj/structure/railing{
+	color = "#36373a";
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -23
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"Sy" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/item/plate{
+	pixel_x = -2;
+	pixel_y = 0
+	},
+/obj/item/plate{
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/obj/item/plate{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/item/plate{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"SD" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"SF" = (
+/obj/item/reagent_containers/cup/bottle/succubus_milk{
+	pixel_x = -5;
+	pixel_y = -6
+	},
+/obj/item/reagent_containers/cup/bottle/succubus_milk{
+	pixel_x = 10;
+	pixel_y = 6
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/hay,
+/area/misc/condo)
+"SJ" = (
+/obj/machinery/griddle/frontier_tabletop,
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"SL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/shuttle/exploration/corner_invcorner{
+	dir = 4
+	},
+/area/misc/condo)
+"Ta" = (
+/obj/structure/rack,
+/obj/item/mop/advanced,
+/obj/item/storage/bag/trash,
+/obj/item/storage/box/lights/mixed,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Tl" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/dresser,
+/obj/item/sign/flag/syndicate{
+	pixel_x = 1;
+	pixel_y = 13
+	},
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Tn" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"Tz" = (
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/bot,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"TN" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 8
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/iron/half{
+	dir = 1
+	},
+/area/misc/condo)
+"TT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing/corner/end{
+	dir = 8;
+	color = "#36373a";
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#59595a";
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"TY" = (
+/obj/structure/gs13_fluff/brokenhose/scraps3,
+/turf/open/floor/hay,
+/area/misc/condo)
+"TZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/misc/condo)
+"Ue" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark/corner,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Uf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/iron/shuttle/exploration/side,
+/area/misc/condo)
+"Ut" = (
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/light{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding{
+	dir = 10
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+"UA" = (
+/obj/item/radio,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"UF" = (
+/obj/machinery/chem_dispenser/drinks/fullupgrade{
+	dir = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"UI" = (
+/obj/item/clothing/mask/ballgag{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/food/cake/chocolate{
+	pixel_x = 4;
+	pixel_y = 19
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"UM" = (
+/obj/structure/closet/crate/secure/weapon,
+/obj/item/clothing/glasses/hud/health/night,
+/obj/item/gun/energy/fatoray,
+/obj/item/gun/energy/laser/alter_ray/gainrate,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/item/melee/baton/stunsword,
+/obj/item/melee/baton/stunsword,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"UO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/misc/condo)
+"UP" = (
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/space/basic,
+/area/misc/condo)
+"US" = (
+/obj/structure/cable,
+/obj/item/shell/bot{
+	name = "skyrat Sector server";
+	desc = "There's a sticky note on the side. It says 'Todo: Fix Serenity Station Crash Issues'";
+	anchored = 1;
+	pixel_x = 7;
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/misc/condo)
+"UZ" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/structure/decorative{
+	icon = 'modular_skyrat/modules/advanced_shuttles/icons/computer.dmi';
+	icon_state = "computer_right";
+	anchored = 1
+	},
+/obj/structure/decorative{
+	icon_state = "intercom";
+	pixel_y = 31;
+	icon = 'icons/obj/machines/wallmounts.dmi';
+	base_icon_state = "tile_half";
+	dir = 8;
+	anchored = 1;
+	name = "Intercom";
+	desc = "An older model version of a standard intercom system."
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Va" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/vending/dinnerware{
+	free = 1
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Vg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Vk" = (
+/obj/structure/rack/shelf,
+/obj/item/trash/syndi_cakes,
+/obj/item/trash/syndi_cakes,
+/obj/item/food/chips,
+/obj/item/food/chips,
+/obj/item/food/cornchips,
+/obj/item/food/cornchips,
+/obj/item/food/candy,
+/obj/item/food/candy,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Vx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/machinery/space_heater/wall_mounted/directional/north{
+	cell = /obj/item/stock_parts/power_store/cell/high;
+	pixel_y = -30
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"VA" = (
+/obj/structure/sign/warning/radiation{
+	pixel_y = -31
+	},
+/obj/structure/cable,
+/obj/item/shell/server{
+	name = "skyrat Sector server";
+	desc = "On the side you see a small LCD saying 'CONGRATULATIONS ITS BEEN 0 DAYS SINCE A UNIT TEST FAILED! A NEW RECORD!'";
+	anchored = 1;
+	pixel_x = -11;
+	pixel_y = 1
+	},
+/obj/structure/fluff/bus/passable/seat{
+	icon = 'icons/obj/machines/telecomms.dmi';
+	icon_state = "blackbox_b";
+	density = 1;
+	pixel_y = 0;
+	uses_integrity = 0;
+	name = "Copium Mining Server";
+	desc = "400TB of various tears and crashouts from maintainers and contributors alike. We're not sure how you got this many, but it's probably best not to ask.";
+	pixel_x = 12
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/misc/condo)
+"VE" = (
+/turf/closed/mineral/random,
+/area/misc/condo)
+"VF" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"VI" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"VO" = (
+/obj/item/trash/can{
+	pixel_x = 11;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#5d341f";
+	dir = 2
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"VR" = (
+/obj/structure/cable,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"VU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/railing/corner/end{
+	dir = 4;
+	color = "#36373a"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/half{
+	alpha = 255;
+	color = "#59595a";
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"Wd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/iron/shuttle/exploration/doubleside,
+/area/misc/condo)
+"Wj" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Wl" = (
+/obj/machinery/door/airlock/hatch,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"Wn" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"Ws" = (
+/obj/structure/chair/sofa/corp/left,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Wv" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"Wx" = (
+/obj/item/storage/bag/plants,
+/obj/effect/turf_decal/siding/dark/end,
+/obj/effect/turf_decal/trimline/dark_green/end,
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_green/mid_joiner{
+	dir = 8
+	},
+/turf/open/floor/iron/half{
+	dir = 1
+	},
+/area/misc/condo)
+"WB" = (
+/obj/item/trash/fleet_ration,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"WC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/mid_joiner,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/shuttle/exploration/side{
+	dir = 1
+	},
+/area/misc/condo)
+"WM" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/medkit/brute{
+	pixel_x = 0;
+	pixel_y = -2
+	},
+/obj/item/storage/medkit/fire{
+	pixel_x = 0;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"Xg" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 8
+	},
+/obj/structure/chair/sofa/bench{
+	dir = 4
+	},
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/turf/open/floor/iron/small,
+/area/misc/condo)
+"Xj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/item/food/grown/lipofruit,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/misc/condo)
+"Xl" = (
+/obj/item/trash/boritos,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"Xy" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/vending/mealdor{
+	free = 1
+	},
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/turf/open/floor/wood/tile,
+/area/misc/condo)
+"XT" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 5
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 5
+	},
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy"
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/structure/sign/flag/syndicate/directional/south,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"XX" = (
+/obj/machinery/button/door{
+	id = "feederden_cell1";
+	name = "Cell 1 Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = 32;
+	pixel_x = -8
+	},
+/obj/machinery/button/door{
+	id = "feederden_cell2";
+	name = "Cell 2 Control";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = 32;
+	pixel_x = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/obj/machinery/light/floor{
+	brightness = 7.5;
+	pixel_x = 16;
+	pixel_y = -16
+	},
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/shuttle/exploration/doubleinvertcorner_side,
+/area/misc/condo)
+"Yd" = (
+/obj/structure/sign/poster/contraband/corn_oil,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
+/area/misc/condo)
+"Ye" = (
+/obj/effect/turf_decal/siding{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/light/end,
+/obj/structure/sink/directional/north,
+/obj/structure/mirror/directional/south,
+/obj/structure/decorative{
+	icon_state = "drain";
+	icon = 'modular_skyrat/modules/liquids/icons/obj/structures/drains.dmi';
+	base_icon_state = "drain";
+	dir = 8;
+	name = "drain";
+	anchored = 1;
+	pixel_x = 0;
+	pixel_y = 11
+	},
+/turf/open/floor/iron/white/small,
+/area/misc/condo)
+"Yh" = (
+/turf/closed/indestructible/hoteldoor{
+	icon_state = "closed";
+	icon = 'modular_skyrat/modules/aesthetics/airlock/icons/airlocks/external/external.dmi'
+	},
+/area/misc/condo)
+"Yk" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/iron/dark/smooth_large,
+/area/misc/condo)
+"Yp" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/structure/chair/sofa/bench/right{
+	dir = 4
+	},
+/obj/effect/overlay/water,
+/obj/effect/overlay/water/top,
+/obj/structure/marker_beacon/cerulean,
+/turf/open/floor/iron/small,
+/area/misc/condo)
+"Yr" = (
+/obj/machinery/vending/hotdog{
+	onstation = 0;
+	onstation_override = 1;
+	all_products_free = 1
+	},
+/turf/open/floor/iron/shuttle/exploration/textured_flat,
+/area/misc/condo)
+"Yx" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 2;
+	name = "landing marker";
+	picked_color = "Burgundy"
+	},
+/obj/machinery/porta_turret/syndicate/fattening,
+/turf/open/floor/plating,
+/area/misc/condo)
+"YB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_red/line,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"YH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/siding/dark,
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/misc/condo)
+"YJ" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"YR" = (
+/obj/structure/closet/secure_closet/freezer/kitchen/all_access,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"YS" = (
+/obj/machinery/vending/fatty_items,
+/turf/open/floor/iron/shuttle/exploration/textured_flat,
+/area/misc/condo)
+"YX" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/siding/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/shuttle/exploration,
+/area/misc/condo)
+"Zh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/misc/condo)
+"Zi" = (
+/obj/machinery/suit_storage_unit/industrial/syndicatecontractor,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/pod/dark,
+/area/misc/condo)
+"Zk" = (
+/obj/item/trash/fatoray_scrap1,
+/turf/open/misc/asteroid/airless,
+/area/misc/condo)
+"Zo" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/processor{
+	pixel_x = 1;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/misc/condo)
+"ZK" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/red,
+/area/misc/condo)
+"ZX" = (
+/turf/closed/indestructible/hotelwall{
+	color = "#000000"
+	},
+/area/misc/condo)
+"ZZ" = (
+/obj/effect/turf_decal/tile/blue/diagonal_edge,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating/light/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white/diagonal,
+/area/misc/condo)
+
+(1,1,1) = {"
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+"}
+(2,1,1) = {"
+ZX
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+zX
+ri
+VE
+VE
+VE
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(3,1,1) = {"
+ZX
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+VE
+VE
+om
+om
+om
+om
+zX
+Gz
+zX
+zX
+CP
+oj
+zX
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(4,1,1) = {"
+ZX
+nP
+nP
+nP
+nP
+nP
+nP
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+lP
+zX
+zX
+zX
+zX
+zX
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(5,1,1) = {"
+ZX
+nP
+nP
+nP
+nP
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+Gz
+zX
+VE
+VE
+VE
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(6,1,1) = {"
+ZX
+nP
+nP
+nP
+VE
+VE
+VE
+VE
+fq
+cb
+cb
+cb
+cb
+fq
+fq
+fq
+fq
+fq
+fq
+fq
+fq
+fq
+VE
+VE
+VE
+nP
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(7,1,1) = {"
+ZX
+nP
+nP
+VE
+VE
+VE
+VE
+oj
+cb
+OT
+Ko
+Fd
+sc
+cb
+Fe
+ED
+fq
+rO
+da
+Xg
+Yp
+fq
+VE
+VE
+VE
+VE
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(8,1,1) = {"
+ZX
+nP
+nP
+VE
+VE
+VE
+eN
+zX
+cb
+Xl
+Ag
+aX
+dP
+Sl
+HY
+Ji
+fq
+vz
+Qv
+Qw
+DW
+fq
+fq
+fq
+VE
+VE
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(9,1,1) = {"
+ZX
+nP
+VE
+VE
+VE
+VE
+zX
+nd
+Em
+mR
+WB
+Pg
+gE
+ni
+qS
+Kf
+aR
+Ms
+kx
+Bx
+kl
+aR
+co
+fq
+VE
+VE
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(10,1,1) = {"
+ZX
+nP
+VE
+VE
+VE
+VE
+ri
+zX
+cb
+Ne
+yV
+Pg
+cM
+MO
+Cc
+pm
+aR
+jk
+BY
+EF
+bK
+aR
+Dy
+fq
+VE
+VE
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(11,1,1) = {"
+ZX
+nP
+nP
+VE
+VE
+VE
+oj
+UA
+fq
+cb
+Cl
+cb
+cb
+fq
+XX
+dv
+fq
+cb
+cb
+fq
+fq
+cb
+cb
+cb
+fq
+VE
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(12,1,1) = {"
+ZX
+nP
+nP
+Gz
+VE
+VE
+VE
+lW
+fq
+RE
+SF
+LH
+is
+Sl
+pt
+Hb
+cb
+tY
+xQ
+Yr
+fq
+zS
+mf
+Bo
+cb
+VE
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(13,1,1) = {"
+ZX
+nP
+nP
+zX
+zX
+VE
+VE
+VE
+fq
+HP
+TY
+zD
+Wd
+vT
+rt
+Es
+cb
+fr
+QD
+EU
+cb
+td
+KU
+DN
+cb
+VE
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(14,1,1) = {"
+ZX
+nP
+nP
+oj
+zX
+zX
+zX
+VE
+fq
+xd
+lq
+vq
+aD
+QP
+vc
+Es
+cb
+PL
+kU
+YS
+cb
+UO
+Xj
+xv
+cb
+VE
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(15,1,1) = {"
+ZX
+nP
+nP
+VE
+zX
+fq
+fq
+fq
+fq
+fq
+cb
+cb
+cb
+fq
+Av
+cp
+cb
+fq
+Hh
+fq
+fq
+cb
+MK
+cb
+fq
+VE
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(16,1,1) = {"
+ZX
+nP
+nP
+VE
+oj
+fq
+Tl
+rH
+fq
+gZ
+pp
+bX
+iw
+fq
+tb
+tE
+cb
+Vk
+rl
+NY
+Rc
+tw
+qC
+UM
+cb
+VE
+VE
+nP
+nP
+nP
+nP
+ZX
+"}
+(17,1,1) = {"
+ZX
+nP
+nP
+VE
+VE
+fq
+Nb
+cd
+Yk
+dj
+cY
+hd
+ui
+If
+Ie
+TT
+cb
+bt
+ib
+Zh
+wc
+ib
+yS
+IO
+cb
+VE
+VE
+nP
+nP
+nP
+nP
+ZX
+"}
+(18,1,1) = {"
+ZX
+nP
+nP
+VE
+VE
+fq
+yE
+pi
+fq
+Og
+rg
+qB
+ty
+tr
+NH
+mU
+cb
+px
+GV
+hW
+ox
+Oi
+Cf
+WM
+cb
+VE
+VE
+nP
+nP
+nP
+nP
+ZX
+"}
+(19,1,1) = {"
+ZX
+nP
+nP
+VE
+Gz
+fq
+fq
+fq
+fq
+UZ
+gz
+DJ
+Jj
+fq
+Ke
+ts
+cb
+MU
+zh
+Bk
+Au
+zh
+Op
+LB
+cb
+VE
+VE
+VE
+nP
+nP
+nP
+ZX
+"}
+(20,1,1) = {"
+ZX
+nP
+nP
+zX
+zX
+oj
+VE
+VE
+fq
+fq
+Sl
+Sl
+fq
+fq
+JD
+OZ
+cb
+HA
+Vg
+Cz
+ie
+sG
+Ta
+Cr
+cb
+VE
+VE
+VE
+VE
+nP
+nP
+ZX
+"}
+(21,1,1) = {"
+ZX
+nP
+nP
+zX
+lP
+Gz
+VE
+VE
+fq
+Cm
+Im
+Im
+bR
+Va
+JD
+vM
+fq
+cb
+Yk
+iX
+cb
+fq
+fq
+fq
+cb
+VE
+Yx
+lP
+VE
+nP
+nP
+ZX
+"}
+(22,1,1) = {"
+ZX
+nP
+VE
+zX
+oj
+cb
+fq
+cb
+fq
+PQ
+Mr
+wE
+wE
+Jp
+JD
+OZ
+Re
+vw
+Cu
+JI
+tX
+Yk
+uy
+sy
+cb
+VE
+lP
+zX
+nP
+nP
+nP
+ZX
+"}
+(23,1,1) = {"
+ZX
+VE
+VE
+lP
+zX
+Sl
+aW
+Ab
+KN
+wo
+sa
+sa
+sa
+Wj
+nW
+YH
+pM
+zz
+vV
+Ig
+mj
+cb
+Nq
+sq
+cb
+VE
+om
+nP
+nP
+nP
+nP
+ZX
+"}
+(24,1,1) = {"
+ZX
+VE
+VE
+zX
+Sl
+Sl
+kR
+hD
+zR
+lf
+uZ
+cb
+Qc
+FV
+vF
+ts
+Yd
+no
+mB
+wy
+SJ
+cb
+cb
+cb
+fq
+UP
+om
+nP
+nP
+nP
+nP
+ZX
+"}
+(25,1,1) = {"
+ZX
+VE
+CP
+zX
+Sl
+xr
+yX
+Hn
+uA
+lf
+UF
+bD
+Hx
+FV
+JD
+OZ
+Sl
+iN
+tv
+VF
+wb
+cb
+mb
+mb
+zZ
+nP
+om
+nP
+nP
+nP
+nP
+ZX
+"}
+(26,1,1) = {"
+ZX
+zX
+zX
+zX
+Sl
+Qn
+jG
+bd
+uA
+VO
+nt
+bD
+Dz
+FV
+JD
+OZ
+Sl
+Kb
+NN
+VF
+RJ
+Sl
+mb
+mb
+kN
+nP
+om
+nP
+nP
+nP
+nP
+ZX
+"}
+(27,1,1) = {"
+ZX
+VE
+lP
+zX
+Sl
+hJ
+YJ
+mD
+AJ
+lf
+op
+bD
+fn
+FV
+JD
+OZ
+Sl
+xs
+tv
+VF
+iO
+cb
+mb
+mb
+zZ
+nP
+om
+nP
+nP
+nP
+nP
+ZX
+"}
+(28,1,1) = {"
+ZX
+VE
+Gz
+zX
+Sl
+Sl
+Ca
+Oa
+Sy
+lf
+jv
+cb
+Ws
+jj
+lE
+wB
+ca
+IC
+NG
+Nl
+if
+cb
+Yh
+Yh
+fq
+UP
+om
+nP
+VE
+VE
+nP
+ZX
+"}
+(29,1,1) = {"
+ZX
+zX
+zX
+zX
+Jx
+Sl
+RN
+UI
+JZ
+Wn
+tN
+tN
+tN
+aq
+eT
+ny
+pM
+Wv
+yr
+ep
+hC
+cb
+yj
+TZ
+cb
+VE
+lP
+zX
+VE
+VE
+VE
+ZX
+"}
+(30,1,1) = {"
+ZX
+VE
+VE
+lP
+zX
+cb
+fq
+fq
+fq
+Xy
+wE
+wE
+Rt
+Jp
+JD
+as
+fq
+dd
+YR
+jB
+Zo
+cb
+fO
+dL
+cb
+VE
+Lx
+lP
+zX
+VE
+VE
+ZX
+"}
+(31,1,1) = {"
+ZX
+nP
+VE
+VE
+CP
+ri
+VE
+VE
+fq
+ke
+hr
+ce
+ce
+qz
+JD
+Vx
+fq
+cb
+cb
+cb
+cb
+fq
+rQ
+rQ
+cb
+VE
+lP
+ri
+zX
+lP
+VE
+ZX
+"}
+(32,1,1) = {"
+ZX
+nP
+nP
+zX
+zX
+oj
+VE
+VE
+fq
+fq
+fq
+NW
+lG
+Gu
+JD
+as
+cb
+Tz
+ja
+Zi
+cb
+py
+pe
+wP
+cb
+VE
+oj
+lP
+CP
+zX
+VE
+ZX
+"}
+(33,1,1) = {"
+ZX
+nP
+nP
+nP
+om
+zX
+VE
+VE
+VE
+VE
+fq
+PG
+fB
+FW
+AY
+cy
+cb
+ff
+pY
+AC
+cb
+EK
+pY
+RK
+cb
+fq
+fq
+fq
+oj
+zX
+ri
+ZX
+"}
+(34,1,1) = {"
+ZX
+nP
+nP
+nP
+om
+nP
+nP
+VE
+VE
+fq
+fq
+Yk
+fq
+fq
+SD
+YB
+jM
+qP
+mk
+mk
+Fp
+KL
+gy
+dx
+Wl
+NF
+Bd
+fq
+zX
+zX
+ri
+ZX
+"}
+(35,1,1) = {"
+ZX
+nP
+nP
+nP
+om
+nP
+nP
+VE
+VE
+fq
+Ll
+bJ
+XT
+fq
+hH
+VU
+cb
+vi
+PX
+fk
+IF
+ou
+OF
+dr
+cb
+Ap
+VA
+fq
+zX
+zX
+zX
+ZX
+"}
+(36,1,1) = {"
+ZX
+ri
+Gz
+VE
+om
+nP
+nP
+VE
+VE
+fq
+cs
+BX
+jr
+fq
+qD
+Kz
+cb
+QA
+Rf
+na
+Iy
+Tn
+mF
+Qq
+cb
+up
+US
+fq
+zX
+Gz
+nP
+ZX
+"}
+(37,1,1) = {"
+ZX
+Gz
+Yx
+VE
+fq
+fq
+fq
+fq
+fq
+fq
+cb
+cb
+cb
+fq
+CN
+SL
+cb
+cb
+ME
+cb
+fq
+cb
+VI
+cb
+fq
+fq
+fq
+fq
+VE
+zX
+nP
+ZX
+"}
+(38,1,1) = {"
+ZX
+Gz
+VE
+VE
+fq
+ez
+nf
+Ue
+gj
+se
+sf
+oV
+kt
+Sl
+oO
+Es
+cb
+iM
+jP
+CC
+cb
+Hv
+JU
+YX
+Fx
+Fx
+Fx
+fq
+VE
+VE
+nP
+ZX
+"}
+(39,1,1) = {"
+ZX
+nP
+VE
+VE
+fq
+FG
+oU
+eX
+xa
+sO
+me
+VR
+st
+Ee
+PV
+Es
+cb
+jA
+kK
+Df
+Yk
+ct
+vn
+vG
+Rh
+TN
+Wx
+fq
+VE
+VE
+nP
+ZX
+"}
+(40,1,1) = {"
+ZX
+nP
+nP
+VE
+fq
+su
+EO
+hQ
+oL
+xR
+aS
+Sd
+jY
+QP
+Dl
+OD
+cb
+oM
+IB
+yY
+cb
+dK
+kc
+iF
+Fx
+Fx
+Fx
+fq
+VE
+VE
+nP
+ZX
+"}
+(41,1,1) = {"
+ZX
+nP
+nP
+nP
+fq
+fq
+fq
+fq
+fq
+cb
+Cl
+cb
+cb
+fq
+rP
+IM
+fq
+cb
+cb
+fq
+fq
+cb
+gj
+Fm
+OG
+fq
+fq
+fq
+VE
+VE
+nP
+ZX
+"}
+(42,1,1) = {"
+ZX
+nP
+nP
+nP
+om
+nP
+VE
+VE
+cb
+BO
+GM
+Qx
+gE
+gx
+AB
+qb
+aR
+xu
+cC
+cb
+VE
+lP
+Gz
+Bh
+rN
+VE
+VE
+VE
+VE
+nP
+nP
+ZX
+"}
+(43,1,1) = {"
+ZX
+nP
+nP
+nP
+om
+nP
+VE
+VE
+cb
+QU
+yo
+Pg
+qJ
+rk
+WC
+Uf
+aR
+ZZ
+Ut
+cb
+Lx
+lP
+zX
+oj
+zX
+zX
+oj
+nP
+nP
+nP
+nP
+ZX
+"}
+(44,1,1) = {"
+ZX
+nP
+nP
+nP
+om
+VE
+VE
+VE
+cb
+ZK
+nk
+Pg
+sn
+Sl
+rJ
+RP
+fq
+aR
+aR
+fq
+Zk
+zX
+zX
+zX
+zX
+zX
+zX
+nP
+nP
+nP
+nP
+ZX
+"}
+(45,1,1) = {"
+ZX
+nP
+nP
+nP
+VE
+VE
+VE
+VE
+cb
+Ne
+qd
+ET
+ht
+cb
+Fe
+ED
+fq
+zf
+Ye
+fq
+oj
+zX
+zX
+zX
+Gz
+VE
+VE
+nP
+nP
+nP
+nP
+ZX
+"}
+(46,1,1) = {"
+ZX
+nP
+nP
+nP
+VE
+VE
+VE
+VE
+fq
+cb
+cb
+cb
+cb
+fq
+fq
+fq
+fq
+fq
+fq
+fq
+VE
+Gz
+zX
+zX
+CP
+VE
+VE
+nP
+nP
+nP
+nP
+ZX
+"}
+(47,1,1) = {"
+ZX
+nP
+nP
+nP
+nP
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+VE
+nP
+nP
+VE
+VE
+VE
+VE
+VE
+zX
+zX
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(48,1,1) = {"
+ZX
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+VE
+VE
+VE
+VE
+VE
+VE
+nP
+nP
+nP
+nP
+nP
+nP
+VE
+VE
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+nP
+ZX
+"}
+(49,1,1) = {"
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+ZX
+"}

--- a/modular_gs/code/modules/condos/condo_templates.dm
+++ b/modular_gs/code/modules/condos/condo_templates.dm
@@ -3,5 +3,5 @@
 /datum/map_template/condo/feederden
 	name = "Condo - Syndicate Feeder Den"
 	mappath = "modular_gs/code/modules/condos/_maps/feeder_den.dmm"
-	landing_zone_x_offset = 28
+	landing_zone_x_offset = 29
 	landing_zone_y_offset = 9

--- a/modular_gs/code/modules/condos/condo_templates.dm
+++ b/modular_gs/code/modules/condos/condo_templates.dm
@@ -1,0 +1,7 @@
+/// Keep these alphabetical.
+
+/datum/map_template/condo/feederden
+	name = "Condo - Syndicate Feeder Den"
+	mappath = "modular_gs/code/modules/condos/_maps/feeder_den.dmm"
+	landing_zone_x_offset = 28
+	landing_zone_y_offset = 9

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7134,6 +7134,7 @@
 #include "modular_gs\code\modules\clothing\under\jobs\modular_items.dm"
 #include "modular_gs\code\modules\clothing\under\jobs\modular_clothing\button_up.dm"
 #include "modular_gs\code\modules\clothing\under\jobs\modular_clothing\dual_tone.dm"
+#include "modular_gs\code\modules\condos\condo_templates.dm"
 #include "modular_gs\code\modules\customization\modules\client\augment\organs.dm"
 #include "modular_gs\code\modules\customization\modules\mob\living\carbon\human\species\hemophage\hemophage_status_effects.dm"
 #include "modular_gs\code\modules\customization\species\proteans\organs\protean_stomach.dm"


### PR DESCRIPTION
Created a new ghost cafe condo: Feeder Den. Base port of the ruin by @Icepick100 , I revamped the appearance of the amp and upgraded the looks, alongside adding a few extra rooms or details.

:cl:
add: added a file for GS13 condos
map: added a new ghost cafe condo: Feeder Den (with the help of @icepick100)
/:cl:

<img width="1454" height="1039" alt="image" src="https://github.com/user-attachments/assets/ae3556b0-2aa6-472d-8c3a-57fa23270429" />
