### PR TITLE
Adds buildable tiny fans.

### DIFF
--- a/modular_gs/modules/modular_items/code/fan.dm
+++ b/modular_gs/modules/modular_items/code/fan.dm
@@ -1,0 +1,61 @@
+/obj/machinery/nova/fan //Due to constrains, atmos effects arent stopped on depower, so only the self powered version is player buildable.
+	name = "tiny fan"
+	desc = "A tiny fan, releasing a thin gust of air."
+	layer = HIGH_PIPE_LAYER
+	power_channel = AREA_USAGE_ENVIRON
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION
+	use_power = IDLE_POWER_USE
+	max_integrity = 150
+	density = FALSE
+	icon = 'icons/obj/mining_zones/survival_pod.dmi'
+	icon_state = "fan_tiny"
+	can_atmos_pass = ATMOS_PASS_NO
+	rad_insulation = RAD_LIGHT_INSULATION
+	resistance_flags = FIRE_PROOF | FREEZE_PROOF
+
+/obj/machinery/nova/fan/Initialize(mapload)
+	. = ..()
+	air_update_turf(TRUE, TRUE)
+
+/obj/machinery/nova/fan/Destroy()
+	air_update_turf(TRUE, FALSE)
+	. = ..()
+
+/obj/machinery/nova/fan/self_powered/on_deconstruction(disassembled)
+	new /obj/item/stack/sheet/iron(drop_location(), 5)
+	new /obj/item/stack/cable_coil/five(drop_location())
+
+/obj/machinery/nova/fan/block_superconductivity()
+	if (machine_stat & (BROKEN|NOPOWER))
+		return FALSE
+	return TRUE
+
+/obj/machinery/nova/fan/wrench_act(mob/living/user, obj/item/tool)
+	loc.balloon_alert_to_viewers("deconstructing...")
+	if(!tool.use_tool(src, user, 2 SECONDS, volume = 50))
+		return ITEM_INTERACT_BLOCKING
+	loc.balloon_alert_to_viewers("deconstructed!")
+	deconstruct(TRUE)
+	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/nova/fan/self_powered
+	name = "self-powered tiny fan"
+	desc = parent_type::desc + " This one seems to have a heated plasma shard that propels the blades!"
+	use_power = NO_POWER_USE
+
+/obj/machinery/nova/fan/self_powered/on_deconstruction(disassembled)
+	. = ..()
+	new /obj/item/stack/sheet/mineral/plasma(drop_location())
+
+/datum/crafting_recipe/nova/fan/self
+	name = "Self-Powered Tiny Fan"
+	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
+	result = /obj/machinery/nova/fan/self_powered
+	reqs = list(
+		/obj/item/pipe = 1,
+		/obj/item/stack/sheet/iron = 4,
+		/obj/item/stack/cable_coil = 5,
+		/obj/item/stack/sheet/mineral/plasma = 1,
+	)
+	time = 2 SECONDS
+	category = CAT_ATMOSPHERIC

--- a/modular_gs/modules/modular_items/code/fan.dm
+++ b/modular_gs/modules/modular_items/code/fan.dm
@@ -42,6 +42,11 @@
 	name = "self-powered tiny fan"
 	desc = parent_type::desc + " This one seems to have a heated plasma shard that propels the blades!"
 	use_power = NO_POWER_USE
+	custom_materials = list(
+		/datum/material/alloy/plasteel = SHEET_MATERIAL_AMOUNT * 4,
+		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 1.05,
+		/datum/material/plasma = SHEET_MATERIAL_AMOUNT,
+		/datum/material/glass = SMALL_MATERIAL_AMOUNT * 0.5)
 
 /obj/machinery/fan/self_powered/on_deconstruction(disassembled)
 	. = ..()

--- a/modular_gs/modules/modular_items/code/fan.dm
+++ b/modular_gs/modules/modular_items/code/fan.dm
@@ -1,4 +1,4 @@
-/obj/machinery/nova/fan //Due to constrains, atmos effects arent stopped on depower, so only the self powered version is player buildable.
+/obj/machinery/fan //Due to constrains, atmos effects arent stopped on depower, so only the self powered version is player buildable. Ported from Novasector.
 	name = "tiny fan"
 	desc = "A tiny fan, releasing a thin gust of air."
 	layer = HIGH_PIPE_LAYER
@@ -13,24 +13,24 @@
 	rad_insulation = RAD_LIGHT_INSULATION
 	resistance_flags = FIRE_PROOF | FREEZE_PROOF
 
-/obj/machinery/nova/fan/Initialize(mapload)
+/obj/machinery/fan/Initialize(mapload)
 	. = ..()
 	air_update_turf(TRUE, TRUE)
 
-/obj/machinery/nova/fan/Destroy()
+/obj/machinery/fan/Destroy()
 	air_update_turf(TRUE, FALSE)
 	. = ..()
 
-/obj/machinery/nova/fan/self_powered/on_deconstruction(disassembled)
-	new /obj/item/stack/sheet/iron(drop_location(), 5)
+/obj/machinery/fan/self_powered/on_deconstruction(disassembled)
+	new /obj/item/stack/sheet/plasteel(drop_location(), 4)
 	new /obj/item/stack/cable_coil/five(drop_location())
 
-/obj/machinery/nova/fan/block_superconductivity()
+/obj/machinery/fan/block_superconductivity()
 	if (machine_stat & (BROKEN|NOPOWER))
 		return FALSE
 	return TRUE
 
-/obj/machinery/nova/fan/wrench_act(mob/living/user, obj/item/tool)
+/obj/machinery/fan/wrench_act(mob/living/user, obj/item/tool)
 	loc.balloon_alert_to_viewers("deconstructing...")
 	if(!tool.use_tool(src, user, 2 SECONDS, volume = 50))
 		return ITEM_INTERACT_BLOCKING
@@ -38,22 +38,22 @@
 	deconstruct(TRUE)
 	return ITEM_INTERACT_SUCCESS
 
-/obj/machinery/nova/fan/self_powered
+/obj/machinery/fan/self_powered
 	name = "self-powered tiny fan"
 	desc = parent_type::desc + " This one seems to have a heated plasma shard that propels the blades!"
 	use_power = NO_POWER_USE
 
-/obj/machinery/nova/fan/self_powered/on_deconstruction(disassembled)
+/obj/machinery/fan/self_powered/on_deconstruction(disassembled)
 	. = ..()
 	new /obj/item/stack/sheet/mineral/plasma(drop_location())
 
-/datum/crafting_recipe/nova/fan/self
+/datum/crafting_recipe/tiny_fan
 	name = "Self-Powered Tiny Fan"
 	tool_behaviors = list(TOOL_WRENCH, TOOL_WELDER)
-	result = /obj/machinery/nova/fan/self_powered
+	result = /obj/machinery/fan/self_powered
 	reqs = list(
 		/obj/item/pipe = 1,
-		/obj/item/stack/sheet/iron = 4,
+		/obj/item/stack/sheet/plasteel = 4,
 		/obj/item/stack/cable_coil = 5,
 		/obj/item/stack/sheet/mineral/plasma = 1,
 	)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7439,6 +7439,7 @@
 #include "modular_gs\code\structures\sink.dm"
 #include "modular_gs\code\structures\trapped_items.dm"
 #include "modular_gs\gatofication\obj\signs.dm"
+#include "modular_gs\modules\modular_items\code\fan.dm"
 #include "modular_gs\modules\plumbing\plumbing_machines.dm"
 #include "modular_skyrat\master_files\code\_globalvars\configuration.dm"
 #include "modular_skyrat\master_files\code\_globalvars\regexes.dm"


### PR DESCRIPTION
I stole this from Nova sector and it just worked.

## About The Pull Request

You can now build tinyfans ingame, I mean hell, they're used EVERYWHERE.

## Why It's Good For The Game

This allows the ability for engineers to be more safe, with the added bonus of making things neater without 1000 holofans.

Also its just generally really nice to have, either on lavaland, in space, or otherwise. I think they were on the last server too so I guess its a messed up port in some kind of way?

## Proof Of Testing


https://github.com/user-attachments/assets/69b16423-4e92-4fa3-bee0-3ee99821662f
(The 4 Iron got changed to 4 plasteel)

https://github.com/user-attachments/assets/c1f7a447-2683-4d20-9f64-99e9156234c0



</details>

## Changelog

:cl:
add: Added buildable tiny fans.
/:cl: