### PR TITLE
Adds Lisping

### DIFF
--- a/code/__DEFINES/~~gs_defines/traits.dm
+++ b/code/__DEFINES/~~gs_defines/traits.dm
@@ -68,6 +68,8 @@
 #define TRAIT_HELPLESS_WEAK_LUNGS		"weak_lungs"
 #define TRAIT_HELPLESS_WADDLING         "waddling_helpless"
 #define TRAIT_WADDLE					"waddle"
+#define TRAIT_HELPLESS_LISP				"lisp_helpless"
+#define TRAIT_LISP						"lisp"
 
 // GS13 positive quirks
 #define TRAIT_BLOB_BED					"blob_bed"

--- a/modular_gs/code/datums/helplessness/helplessness.dm
+++ b/modular_gs/code/datums/helplessness/helplessness.dm
@@ -229,6 +229,36 @@
 		return
 	REMOVE_TRAIT(fatty, TRAIT_WADDLING, REF(fatty))
 
+/datum/helplessness/lisp
+	helplessness_trait = TRAIT_LISP
+	default_trigger_weight = FATNESS_LEVEL_BARELYMOBILE
+	override_quirk = TRAIT_HELPLESS_LISP
+	preference = /datum/preference/numeric/helplessness/lisp
+	gain_message = "Your face feelth too big to pronouce thome letterth."
+	lose_message = "Your face has shrunk enough to talk normally again."
+
+/datum/helplessness/lisp/apply_helplessness(mob/living/carbon/human/fatty, trigger_weight, fatness)
+	. = ..()
+	if (!.)
+		return
+	RegisterSignal(fatty, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+
+/datum/helplessness/lisp/disable_helplessness(mob/living/carbon/human/fatty, trigger_weight, fatness)
+	. = ..()
+	if (!.)
+		return
+	UnregisterSignal(fatty, COMSIG_MOB_SAY)
+
+/datum/helplessness/lisp/proc/handle_speech(datum/source, list/speech_args)
+	SIGNAL_HANDLER
+	if(HAS_TRAIT(source, TRAIT_SIGN_LANG))
+		return
+	var/message = speech_args[SPEECH_MESSAGE]
+	if(message)
+		message = replacetext(message,"s","th")
+		message = replacetext(message,"x","th")
+		speech_args[SPEECH_MESSAGE] = message
+
 #define MAX_PRESSURE_DEBUFF 0.5
 /*
 /datum/helplessness/weak_lungs

--- a/modular_gs/code/datums/quirks/neutral/lisp.dm
+++ b/modular_gs/code/datums/quirks/neutral/lisp.dm
@@ -1,6 +1,7 @@
 /datum/quirk/lisp //Ported from Monkestation.
 	name = "Lisp"
 	desc = "You have a hard time pronoucing thome letterth. Not recommended for people with lizard tongues, Use the organs menu to swap it out."
+	medical_record_text = "Patient has a lisp."
 	value = 0
 	icon = FA_ICON_GRIN_TONGUE
 

--- a/modular_gs/code/datums/quirks/neutral/lisp.dm
+++ b/modular_gs/code/datums/quirks/neutral/lisp.dm
@@ -1,6 +1,6 @@
-/datum/quirk/lisp
+/datum/quirk/lisp //Ported from Monkestation.
 	name = "Lisp"
-	desc = "You have a hard time pronoucing thome letterth. Not reccomended for people with lizard tongues, Use the organs menu to swap it out."
+	desc = "You have a hard time pronoucing thome letterth. Not recommended for people with lizard tongues, Use the organs menu to swap it out."
 	value = 0
 	icon = FA_ICON_GRIN_TONGUE
 

--- a/modular_gs/code/datums/quirks/neutral/lisp.dm
+++ b/modular_gs/code/datums/quirks/neutral/lisp.dm
@@ -1,0 +1,21 @@
+/datum/quirk/lisp
+	name = "Lisp"
+	desc = "You have a hard time pronoucing thome letterth. Not reccomended for people with lizard tongues, Use the organs menu to swap it out."
+	value = 0
+	icon = FA_ICON_GRIN_TONGUE
+
+/datum/quirk/lisp/add()
+	RegisterSignal(quirk_holder, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+
+/datum/quirk/lisp/remove()
+	UnregisterSignal(quirk_holder, COMSIG_MOB_SAY)
+
+/datum/quirk/lisp/proc/handle_speech(datum/source, list/speech_args)
+	SIGNAL_HANDLER
+	if(HAS_TRAIT(source, TRAIT_SIGN_LANG))
+		return
+	var/message = speech_args[SPEECH_MESSAGE]
+	if(message)
+		message = replacetext(message,"s","th")
+		message = replacetext(message,"x","th")
+		speech_args[SPEECH_MESSAGE] = message

--- a/modular_gs/code/modules/client/preferences/helplessness_prefs.dm
+++ b/modular_gs/code/modules/client/preferences/helplessness_prefs.dm
@@ -91,6 +91,10 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "waddle"
 
+/datum/preference/numeric/helplessness/lisp
+	category = HELPLESSNESS_PREFERENCES
+	savefile_identifier = PREFERENCE_CHARACTER
+	savefile_key = "lisp"
 /*
 /datum/preference/numeric/helplessness/weak_lungs
 	category = HELPLESSNESS_PREFERENCES

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7226,6 +7226,7 @@
 #include "modular_gs\code\datums\quirks\negative\fat_aversion.dm"
 #include "modular_gs\code\datums\quirks\negative\negative_quirks.dm"
 #include "modular_gs\code\datums\quirks\neutral\cosglow.dm"
+#include "modular_gs\code\datums\quirks\neutral\lisp.dm"
 #include "modular_gs\code\datums\quirks\neutral\metal_cruncher.dm"
 #include "modular_gs\code\datums\quirks\neutral\neutral_quirks.dm"
 #include "modular_gs\code\datums\quirks\neutral\tail_sweep.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/gs13/helplessness.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/gs13/helplessness.tsx
@@ -112,6 +112,12 @@ export const waddle: Feature<number> = {
   component: FeatureNumberInput,
 };
 
+export const lisp: Feature<number> = {
+  name: 'Lisping',
+  description: 'At what weight do you start talking with a lisp? 0 disables this.',
+  component: FeatureNumberInput,
+};
+
 /*
 export const weak_lungs: Feature<number> = {
   name: 'Weak lungs',


### PR DESCRIPTION
Adds lisping as a free quirk. Not recommended to use as a lizard, and its clearly stated in the description. If you cant read that's on you. It also adds it as a helplessness pref.

## About The Pull Request

Adds lisping as a free quirk, it replaces s with th and x with th. That's all it does.

## Why It's Good For The Game

More rp flavor without actually needing to focus hard on it is good. It helps prevent the dreaded "RP Fail".

## Proof Of Testing


https://github.com/user-attachments/assets/2aa37d02-8021-46f1-9786-558bdd760da1

https://github.com/user-attachments/assets/c5defee0-35e1-4e67-8608-ba654b132cd8

https://github.com/user-attachments/assets/e86650a9-9745-46ac-ad3c-c65c53676f69

## Changelog

:cl:
add: Added lisping as a free quirk.
/:cl: