### PR TITLE
Stuckage and storyteller vote changes

### DIFF
--- a/_maps/map_files/GS_Xenoarch/Lavaland_Xenoarch.dmm
+++ b/_maps/map_files/GS_Xenoarch/Lavaland_Xenoarch.dmm
@@ -14938,7 +14938,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/power/adipoelectric_generator,
+/obj/machinery/power/adipoelectric_generator/anchored,
 /turf/open/floor/iron,
 /area/mine/xenoarch/engineering)
 "kHJ" = (

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -137,6 +137,7 @@
 
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_MAGICALLY_UNLOCKED = PROC_REF(on_magic_unlock),
+		COMSIG_ATOM_EXIT = PROC_REF(check_door_stuckage),	// GS13 edit - door stuckage
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 	AddElement(/datum/element/can_barricade)

--- a/modular_gs/code/machinery/adipoelectric_generator.dm
+++ b/modular_gs/code/machinery/adipoelectric_generator.dm
@@ -21,6 +21,10 @@
 	var/emp_timer = 0
 	var/active = FALSE
 
+// for mapping
+/obj/machinery/power/adipoelectric_generator/anchored
+	anchored = TRUE
+
 /obj/machinery/power/adipoelectric_generator/Initialize(mapload)
 	. = ..()
 	if(anchored)
@@ -78,6 +82,8 @@
 
 /obj/machinery/power/adipoelectric_generator/wrench_act(mob/living/user, obj/item/tool)
 	default_unfasten_wrench(user, tool)
+	if (anchored)
+		connect_to_network()
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/power/adipoelectric_generator/crowbar_act(mob/living/user, obj/item/tool)

--- a/modular_gs/code/machinery/adipoelectric_transformer.dm
+++ b/modular_gs/code/machinery/adipoelectric_transformer.dm
@@ -24,6 +24,10 @@ GLOBAL_LIST_EMPTY(adipoelectric_transformer)
 	var/emp_multiplier = 5
 	var/active = FALSE
 
+// for mapping
+/obj/machinery/power/adipoelectric_transformer/anchored
+	anchored = TRUE
+
 /obj/machinery/power/adipoelectric_transformer/Initialize(mapload)
 	. = ..()
 	if(anchored)
@@ -98,6 +102,8 @@ GLOBAL_LIST_EMPTY(adipoelectric_transformer)
 
 /obj/machinery/power/adipoelectric_transformer/wrench_act(mob/living/user, obj/item/tool)
 	default_unfasten_wrench(user, tool)
+	if (anchored)
+		connect_to_network()
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/power/adipoelectric_transformer/crowbar_act(mob/living/user, obj/item/tool)

--- a/modular_gs/code/mechanics/stuckage.dm
+++ b/modular_gs/code/mechanics/stuckage.dm
@@ -1,19 +1,14 @@
-/obj/machinery/door/airlock/CanAllowThrough(atom/movable/mover, border_dir)
-	. = ..()
+/obj/machinery/door/proc/check_door_stuckage(datum/source, atom/movable/leaving, direction)
+	if (!istype(leaving, /mob/living/carbon))
+		return
 
-	if (. == FALSE)
-		return .
-
-	if (!istype(mover, /mob/living/carbon))
-		return .
-
-	var/mob/living/carbon/fatty = mover
+	var/mob/living/carbon/fatty = leaving
 
 	if (isnull(fatty.client))
-		return .
+		return
 
 	if (isnull(fatty.client.prefs))
-		return .
+		return
 
 	var/stuckage_weight = fatty.client.prefs.read_preference(/datum/preference/numeric/helplessness/stuckage)
 	var/custom_chance_to_get_stuck = fatty.client.prefs.read_preference(/datum/preference/numeric/helplessness/stuckage_custom)
@@ -23,16 +18,17 @@
 		custom_chance_to_get_stuck = 0
 
 	if (stuckage_weight == 0)
-		return .
+		return
 
 	if (got_stuck_in_door(fatty, stuckage_weight, custom_chance_to_get_stuck))
 		fatty.visible_message("<span class'danger'>[fatty] gets stuck in the doorway!</span>")
-		to_chat(fatty, "<span class='danger'>As you attempt to pass through  \the [src], your ample curves get wedged in the narrow opening. You find yourself stuck in the [src] frame, struggling to free yourself from the tight squeeze.</span>")
+		if (prob(15))
+			to_chat(fatty, "<span class='danger'>As you attempt to pass through  \the [src], your ample curves get wedged in the narrow opening. You find yourself stuck in the [src] frame, struggling to free yourself from the tight squeeze.</span>")
 		fatty.Shake(duration = 0.1 SECONDS)
 		update_integrity(atom_integrity - 1)
-		return FALSE
+		return COMPONENT_ATOM_BLOCK_EXIT
 
-/obj/machinery/door/airlock/proc/got_stuck_in_door(mob/living/carbon/fatty, stuckage_weight, custom_chance_to_get_stuck)
+/proc/got_stuck_in_door(mob/living/carbon/fatty, stuckage_weight, custom_chance_to_get_stuck)
 	if(custom_chance_to_get_stuck && fatty.fatness > stuckage_weight)
 		if(prob(custom_chance_to_get_stuck))
 			return TRUE
@@ -57,22 +53,24 @@
 	
 	return FALSE
 
-/obj/structure/mineral_door/CanAllowThrough(atom/movable/mover, border_dir)
+/obj/structure/mineral_door/Initialize(mapload)
 	. = ..()
+	var/static/list/connections = list(
+		COMSIG_ATOM_EXIT = PROC_REF(check_door_stuckage)
+	)
+	AddElement(/datum/element/connect_loc, connections)
 
-	if (. == FALSE)
-		return .
+/obj/structure/mineral_door/proc/check_door_stuckage(datum/source, atom/movable/leaving, direction)
+	if (!istype(leaving, /mob/living/carbon))
+		return
 
-	if (!istype(mover, /mob/living/carbon))
-		return .
-
-	var/mob/living/carbon/fatty = mover
+	var/mob/living/carbon/fatty = leaving
 
 	if (isnull(fatty.client))
-		return .
+		return
 
 	if (isnull(fatty.client.prefs))
-		return .
+		return
 
 	var/stuckage_weight = fatty.client.prefs.read_preference(/datum/preference/numeric/helplessness/stuckage)
 	var/custom_chance_to_get_stuck = fatty.client.prefs.read_preference(/datum/preference/numeric/helplessness/stuckage_custom)
@@ -82,36 +80,12 @@
 		custom_chance_to_get_stuck = 0
 
 	if (stuckage_weight == 0)
-		return .
+		return
 
 	if (got_stuck_in_door(fatty, stuckage_weight, custom_chance_to_get_stuck))
 		fatty.visible_message("<span class'danger'>[fatty] gets stuck in the doorway!</span>")
-		to_chat(fatty, "<span class='danger'>As you attempt to pass through  \the [src], your ample curves get wedged in the narrow opening. You find yourself stuck in the [src] frame, struggling to free yourself from the tight squeeze.</span>")
+		if (prob(15))
+			to_chat(fatty, "<span class='danger'>As you attempt to pass through  \the [src], your ample curves get wedged in the narrow opening. You find yourself stuck in the [src] frame, struggling to free yourself from the tight squeeze.</span>")
 		fatty.Shake(duration = 0.1 SECONDS)
 		update_integrity(atom_integrity - 1)
-		return FALSE
-
-/obj/structure/mineral_door/proc/got_stuck_in_door(mob/living/carbon/fatty, stuckage_weight, custom_chance_to_get_stuck)
-	if(custom_chance_to_get_stuck && fatty.fatness > stuckage_weight)
-		if(prob(custom_chance_to_get_stuck))
-			return TRUE
-		return FALSE
-	
-	if(fatty.fatness > (stuckage_weight * 2))
-		if(prob(66))
-			return TRUE
-		return FALSE
-
-	if(fatty.fatness > stuckage_weight)
-		if(prob(40))
-			return TRUE
-		if(prob(20))
-			to_chat(fatty, "<span class='danger'>With great effort, you manage to squeeze your massive form through  \the [src]. It's a tight fit, but you successfully navigate the narrow opening, barely avoiding getting stuck.</span>")
-			return FALSE
-
-	if(fatty.fatness > (stuckage_weight / 2))
-		if(prob(20))
-			fatty.visible_message("<span class'danger'>[fatty]'s hips brush against the doorway...</span>")
-			to_chat(fatty, "<span class='danger'>As you pass through  \the [src], you feel a slight brushing against your hips. The [src] frame accommodates your form, but it's a close fit..</span>")
-	
-	return FALSE
+		return COMPONENT_ATOM_BLOCK_EXIT

--- a/modular_gs/code/mechanics/stuckage.dm
+++ b/modular_gs/code/mechanics/stuckage.dm
@@ -20,7 +20,7 @@
 	if (stuckage_weight == 0)
 		return
 
-	if (got_stuck_in_door(fatty, stuckage_weight, custom_chance_to_get_stuck))
+	if (got_stuck_in_door(fatty, stuckage_weight, custom_chance_to_get_stuck, src))
 		fatty.visible_message("<span class'danger'>[fatty] gets stuck in the doorway!</span>")
 		if (prob(15))
 			to_chat(fatty, "<span class='danger'>As you attempt to pass through  \the [src], your ample curves get wedged in the narrow opening. You find yourself stuck in the [src] frame, struggling to free yourself from the tight squeeze.</span>")
@@ -28,7 +28,7 @@
 		update_integrity(atom_integrity - 1)
 		return COMPONENT_ATOM_BLOCK_EXIT
 
-/proc/got_stuck_in_door(mob/living/carbon/fatty, stuckage_weight, custom_chance_to_get_stuck)
+/proc/got_stuck_in_door(mob/living/carbon/fatty, stuckage_weight, custom_chance_to_get_stuck, door)
 	if(custom_chance_to_get_stuck && fatty.fatness > stuckage_weight)
 		if(prob(custom_chance_to_get_stuck))
 			return TRUE
@@ -43,13 +43,13 @@
 		if(prob(40))
 			return TRUE
 		if(prob(20))
-			to_chat(fatty, "<span class='danger'>With great effort, you manage to squeeze your massive form through  \the [src]. It's a tight fit, but you successfully navigate the narrow opening, barely avoiding getting stuck.</span>")
+			to_chat(fatty, "<span class='danger'>With great effort, you manage to squeeze your massive form through  \the [door]. It's a tight fit, but you successfully navigate the narrow opening, barely avoiding getting stuck.</span>")
 			return FALSE
 
 	if(fatty.fatness > (stuckage_weight / 2))
 		if(prob(20))
 			fatty.visible_message("<span class'danger'>[fatty]'s hips brush against the doorway...</span>")
-			to_chat(fatty, "<span class='danger'>As you pass through  \the [src], you feel a slight brushing against your hips. The [src] frame accommodates your form, but it's a close fit..</span>")
+			to_chat(fatty, "<span class='danger'>As you pass through  \the [door], you feel a slight brushing against your hips. The [door] frame accommodates your form, but it's a close fit..</span>")
 	
 	return FALSE
 
@@ -82,7 +82,7 @@
 	if (stuckage_weight == 0)
 		return
 
-	if (got_stuck_in_door(fatty, stuckage_weight, custom_chance_to_get_stuck))
+	if (got_stuck_in_door(fatty, stuckage_weight, custom_chance_to_get_stuck, src))
 		fatty.visible_message("<span class'danger'>[fatty] gets stuck in the doorway!</span>")
 		if (prob(15))
 			to_chat(fatty, "<span class='danger'>As you attempt to pass through  \the [src], your ample curves get wedged in the narrow opening. You find yourself stuck in the [src] frame, struggling to free yourself from the tight squeeze.</span>")

--- a/modular_gs/code/modules/storyteller/auto_storyteller_vote.dm
+++ b/modular_gs/code/modules/storyteller/auto_storyteller_vote.dm
@@ -9,6 +9,10 @@
 
 	return VOTE_AVAILABLE
 
+/datum/vote/storyteller/instant/create_vote(mob/vote_creator)
+	default_choices = SSgamemode.storyteller_vote_choices()
+	. = ..()
+
 /datum/vote/storyteller/instant/finalize_vote(winning_option)
 	..()
 	/// Find the winner


### PR DESCRIPTION
## About The Pull Request

Changes it so you get stuck INSIDE airlocks, as well as fixes instant storyteller vote not caring about current pop

## Why It's Good For The Game

Makes stuckage better, makes storyteller votes more accurate

Fixes #497 

## Changelog

:cl: Swan
qol: Getting stuck in doors will now occur on the airlocks tile, rather than in front of it
fix: Instant storyteller vote now takes the current population into account when picking storytellers to include in the vote
fix: fixes the adipoelectric generator in xenoarch not being connected to the grid at round start
/:cl: