### PR TITLE
Weighting and plumbing adjustments

### DIFF
--- a/code/modules/asset_cache/assets/plumbing.dm
+++ b/code/modules/asset_cache/assets/plumbing.dm
@@ -35,6 +35,7 @@
 			"synthesizer_booze",
 			"tap_output",
 		),
+		'modular_gs/icons/obj/plumping.dmi' = list("feed", "milk"),	// GS13 EDIT: makes our icons work in the plumbing device
 	)
 
 	for(var/icon_file in essentials)

--- a/code/modules/research/techweb/nodes/biology_nodes.dm
+++ b/code/modules/research/techweb/nodes/biology_nodes.dm
@@ -12,6 +12,7 @@
 		"ph_meter",
 		"scigoggles",
 		"mod_reagent_scanner",
+		"weightanalyzer",	// GS13 EDIT: adds the weight analyzer
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 	announce_channels = list(RADIO_CHANNEL_MEDICAL)

--- a/modular_gs/code/modules/research/designs/medical_designs.dm
+++ b/modular_gs/code/modules/research/designs/medical_designs.dm
@@ -1,0 +1,13 @@
+/datum/design/weightanalyzer
+	name = "Weight Analyzer"
+	id = "weightanalyzer"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(
+		/datum/material/iron = SMALL_MATERIAL_AMOUNT * 5,
+		/datum/material/glass = SMALL_MATERIAL_AMOUNT * 0.5
+		)
+	build_path = /obj/item/portable_weight_scanner
+	category = list(
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE

--- a/modular_gs/code/modules/vending/gs_vendors.dm
+++ b/modular_gs/code/modules/vending/gs_vendors.dm
@@ -127,6 +127,7 @@
 				/obj/item/reagent_containers/cup/beaker/flatulose = 99,
 				/obj/item/seeds/lipoplant = 99,
 				/obj/item/food/grown/lipofruit = 99,
+				/obj/item/portable_weight_scanner = 99,
 				)
 
 	refill_canister = /obj/item/vending_refill/fattywank
@@ -153,7 +154,8 @@
 				/obj/item/reagent_containers/cup/beaker/lipoifier = 2,
 				/obj/item/reagent_containers/cup/beaker/micro_calorite = 1,
 				/obj/item/dnainjector/fatfang = 2,
-				/obj/item/pen/calorite/syndicate = 4
+				/obj/item/pen/calorite/syndicate = 4,
+				/obj/item/portable_weight_scanner = 3,
 				)
 
 /obj/item/vending_refill/fattywank

--- a/modular_gs/code/modules/weighing/scale.dm
+++ b/modular_gs/code/modules/weighing/scale.dm
@@ -44,23 +44,23 @@
 /obj/structure/scale/examine(mob/user)
 	. = ..()
 	. += "Its last reading was: [last_reading]Lbs"
-	. += "<span class='notice'>It's held together by a couple of <b>bolts</b>.</span>"
+	. += span_notice("It's held together by a couple of <b>bolts</b>.")
 
 /obj/structure/scale/proc/weighEffect(mob/living/carbon/human/fatty)
-	to_chat(fatty, "<span class='notice'>You weigh yourself.</span>")
-	to_chat(fatty, "<span class='notice'>The numbers on the screen tick up and eventually settle on:</span>")
+	to_chat(fatty, span_notice("You weigh yourself."))
+	to_chat(fatty, span_notice("The numbers on the screen tick up and eventually settle on:"))
 	//The appearance of the numbers changes with the fat level of the character
 	if (HAS_TRAIT(fatty, TRAIT_BLOB))
-		to_chat(fatty, "<span class='userdanger'><span class='big'>[round(last_reading/2000, 0.01)]TONS!!!</span></span>")
+		to_chat(fatty, span_userdanger(span_big("[round(last_reading/2000, 0.01)]TONS!!!")))
 
 	else if (HAS_TRAIT(fatty, TRAIT_IMMOBILE))
-		to_chat(fatty, "<span class='boldannounce'>[last_reading]Lbs!</span>")
+		to_chat(fatty, span_bolddanger("[last_reading]Lbs!"))
 
 	else if(HAS_TRAIT(fatty, TRAIT_OBESE) || HAS_TRAIT(fatty, TRAIT_MORBIDLYOBESE))
-		to_chat(fatty, "<span class='alert'>[last_reading]Lbs!</span>")
+		to_chat(fatty, span_alert("[last_reading]Lbs!"))
 
 	else
-		to_chat(fatty, "<span class='notice'>[last_reading]Lbs.</span>")
+		to_chat(fatty, span_notice("[last_reading]Lbs."))
 
 /obj/structure/scale/proc/weighperson(datum/source, mob/living/carbon/fatty)
 	SIGNAL_HANDLER
@@ -69,9 +69,9 @@
 
 	last_reading = fatty.calculate_weight_in_pounds()
 	weighEffect(fatty)
-	visible_message("<span class='notice'>[fatty] weighs themselves.</span>")
-	visible_message("<span class='notice'>The numbers on the screen settle on: [last_reading]Lbs.</span>")
-	visible_message("<span class='notice'>The numbers on the screen read out: [fatty] has a BFI of [fatty.fatness].</span>")
+	visible_message(span_notice("[fatty] weighs themselves."))
+	visible_message(span_notice("The numbers on the screen settle on: [last_reading]Lbs."))
+	visible_message(span_notice("The numbers on the screen read out: [fatty] has a BFI of [fatty.fatness]."))
 
 	if (!isnull(weightee))
 		UnregisterSignal(weightee, COMSIG_FATNESS_CHANGED)
@@ -91,7 +91,7 @@
 		if (istype(potential_fatty, /mob/living/carbon) && !(potential_fatty.movement_type & FLYING))
 			weighperson(source, potential_fatty)
 			return
-	
+
 	weightee = null
 	weight_component.currently_weighing = FALSE
 

--- a/modular_gs/code/modules/weighing/scale.dm
+++ b/modular_gs/code/modules/weighing/scale.dm
@@ -10,9 +10,11 @@
 	layer = OBJ_LAYER
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 3)
 	//stores the weight of the last person to step on in Lbs
-	var/lastreading = 0
+	var/last_reading = 0
 	/// What datum are we using to track weight?
 	var/datum/component/weigh_out/weight_component
+	/// the mob currently being weighted
+	var/mob/living/carbon/weightee
 
 /obj/structure/scale/wrench_act_secondary(mob/living/user, obj/item/tool)
 	..()
@@ -28,7 +30,7 @@
 	. = ..()
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(weighperson),
-		COMSIG_ATOM_EXITED = PROC_REF(stop_weighing),
+		COMSIG_ATOM_EXITED = PROC_REF(check_weightees),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 	weight_component = AddComponent(/datum/component/weigh_out)
@@ -41,7 +43,7 @@
 
 /obj/structure/scale/examine(mob/user)
 	. = ..()
-	. += "Its last reading was: [src.lastreading]Lbs"
+	. += "Its last reading was: [last_reading]Lbs"
 	. += "<span class='notice'>It's held together by a couple of <b>bolts</b>.</span>"
 
 /obj/structure/scale/proc/weighEffect(mob/living/carbon/human/fatty)
@@ -49,34 +51,53 @@
 	to_chat(fatty, "<span class='notice'>The numbers on the screen tick up and eventually settle on:</span>")
 	//The appearance of the numbers changes with the fat level of the character
 	if (HAS_TRAIT(fatty, TRAIT_BLOB))
-		to_chat(fatty, "<span class='userdanger'><span class='big'>[round(src.lastreading/2000, 0.01)]TONS!!!</span></span>")
+		to_chat(fatty, "<span class='userdanger'><span class='big'>[round(last_reading/2000, 0.01)]TONS!!!</span></span>")
 
 	else if (HAS_TRAIT(fatty, TRAIT_IMMOBILE))
-		to_chat(fatty, "<span class='boldannounce'>[src.lastreading]Lbs!</span>")
+		to_chat(fatty, "<span class='boldannounce'>[last_reading]Lbs!</span>")
 
 	else if(HAS_TRAIT(fatty, TRAIT_OBESE) || HAS_TRAIT(fatty, TRAIT_MORBIDLYOBESE))
-		to_chat(fatty, "<span class='alert'>[src.lastreading]Lbs!</span>")
+		to_chat(fatty, "<span class='alert'>[last_reading]Lbs!</span>")
 
 	else
-		to_chat(fatty, "<span class='notice'>[src.lastreading]Lbs.</span>")
+		to_chat(fatty, "<span class='notice'>[last_reading]Lbs.</span>")
 
 /obj/structure/scale/proc/weighperson(datum/source, mob/living/carbon/fatty)
 	SIGNAL_HANDLER
 	if(!istype(fatty) || (fatty.movement_type & FLYING))
 		return FALSE
 
-	src.lastreading = fatty.calculate_weight_in_pounds()
+	last_reading = fatty.calculate_weight_in_pounds()
 	weighEffect(fatty)
 	visible_message("<span class='notice'>[fatty] weighs themselves.</span>")
-	visible_message("<span class='notice'>The numbers on the screen settle on: [src.lastreading]Lbs.</span>")
+	visible_message("<span class='notice'>The numbers on the screen settle on: [last_reading]Lbs.</span>")
 	visible_message("<span class='notice'>The numbers on the screen read out: [fatty] has a BFI of [fatty.fatness].</span>")
 
+	if (!isnull(weightee))
+		UnregisterSignal(weightee, COMSIG_FATNESS_CHANGED)
+	weightee = fatty
+	RegisterSignal(fatty, COMSIG_FATNESS_CHANGED, PROC_REF(update_last_reading))
+
+	weight_component.weigh(fatty)
 	weight_component.currently_weighing = TRUE
 	weight_component.most_recent_carbon = fatty
 
-/obj/structure/scale/proc/stop_weighing(datum/source)
+/// called when an object leaves the scales tile. checks if there are any other valid carbons on the tile and starts weighting them instead
+/obj/structure/scale/proc/check_weightees(datum/source)
 	SIGNAL_HANDLER
+	if (!isnull(weightee))
+		UnregisterSignal(weightee, COMSIG_FATNESS_CHANGED)
+	for (var/mob/living/carbon/potential_fatty as anything in loc)
+		if (istype(potential_fatty, /mob/living/carbon) && !(potential_fatty.movement_type & FLYING))
+			weighperson(source, potential_fatty)
+			return
+	
+	weightee = null
 	weight_component.currently_weighing = FALSE
+
+/obj/structure/scale/proc/update_last_reading(mob/living/carbon/fatty, fatness)
+	SIGNAL_HANDLER
+	last_reading = fatty.calculate_weight_in_pounds()
 
 /obj/structure/scale/ui_interact(mob/user)
 	weight_component.ui_interact(user)

--- a/modular_gs/code/modules/weighing/weight_scanner.dm
+++ b/modular_gs/code/modules/weighing/weight_scanner.dm
@@ -1,12 +1,16 @@
 /obj/item/portable_weight_scanner
 	name = "weight analyzer"
+	desc = "A hand-held body scanner capable of distinguishing the exact composition of someone's body mass."
 	icon = 'modular_gs/icons/obj/items/devices.dmi' //Sprites made by @greeenwoman
 	icon_state = "weight-analyzer"
 	inhand_icon_state = "healthanalyzer"
 	worn_icon_state = "healthanalyzer"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	desc = "A hand-held body scanner capable of distinguishing the exact composition of someone's body mass."
+	custom_materials = list(
+		/datum/material/iron = SMALL_MATERIAL_AMOUNT * 5,
+		/datum/material/glass = SMALL_MATERIAL_AMOUNT * 0.5
+		)
 	var/datum/component/weigh_out/weight_component
 
 /obj/item/portable_weight_scanner/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)

--- a/modular_gs/modules/plumbing/plumbing_machines.dm
+++ b/modular_gs/modules/plumbing/plumbing_machines.dm
@@ -201,6 +201,11 @@
 		return
 
 	if(drip_reagents.total_volume)
+		var/mob/living/carbon/carbon = attached_to
+		if (istype(carbon))
+			var/obj/item/organ/stomach/stomach = carbon.get_organ_slot(ORGAN_SLOT_STOMACH)
+			if (istype(stomach))
+				attached_to = stomach
 		drip_reagents.trans_to(attached_to, transfer_rate * seconds_per_tick, methods = INJECT, show_message = FALSE) //make reagents reacts, but don't spam messages
 		update_appearance(UPDATE_ICON)
 
@@ -247,7 +252,7 @@
 
 	var/atom/movable/target = use_internal_storage ? src : reagent_container
 	var/mob/living/attached_mob = attached_to
-	attached_mob.reagents.trans_to(target, amount)
+	// attached_mob.reagents.trans_to(target, amount)	// idk why we ever took stuff from the bloodstream
 
 	var/obj/item/organ/genital/breasts/breasts = attached_mob.get_organ_slot(ORGAN_SLOT_BREASTS)
 	if(breasts && breasts.is_exposed() && breasts.lactates)

--- a/modular_gs/modules/plumbing/plumbing_machines.dm
+++ b/modular_gs/modules/plumbing/plumbing_machines.dm
@@ -167,6 +167,9 @@
 
 	SEND_SIGNAL(src, COMSIG_IV_ATTACH, target)
 
+/obj/machinery/iv_drip/gs13/on_deconstruction(disassembled)
+	return
+
 /obj/machinery/iv_drip/gs13/plumbing_feeder
 	name = "automated feeder"
 	desc = "A streamlined pluming machine whose sole function is to take all chemicals inside the connected ducts and feed them to whoever is attached to the other end."

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_organs/breasts.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_organs/breasts.dm
@@ -4,7 +4,7 @@
 
 /obj/item/organ/genital/breasts/build_from_dna(datum/dna/DNA, associated_key)
 	. = ..()
-	var/breasts_capacity = 0
+	var/breasts_capacity = 1	// GS13 EDIT makes breasts produce reagents immediately
 	var/size = 0.5
 	if(DNA.features["breasts_size"] > 0)
 		size = DNA.features["breasts_size"]

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7433,6 +7433,7 @@
 #include "modular_gs\code\modules\reagents\reagent_containers\condiment.dm"
 #include "modular_gs\code\modules\research\designs\autolathe.dm"
 #include "modular_gs\code\modules\research\designs\borg.dm"
+#include "modular_gs\code\modules\research\designs\medical_designs.dm"
 #include "modular_gs\code\modules\research\designs\nutri_designs\nutritech_tools_designs.dm"
 #include "modular_gs\code\modules\research\designs\nutri_designs\nutritech_weapon_designs.dm"
 #include "modular_gs\code\modules\research\nanites\nanite_programs\fattening.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes some stuff regarding our weighing scales, as well as our plumbing machines

## Why It's Good For The Game

Fixes bugs

## Changelog

:cl: Swan
add: Enables the handheld weight analyzer - basically a scale which you can hold and use in your hands.
add: The plumbing feeder and milker will no longer put/take reagents from the bloodstream
fix: fixes the plumbing feeder and milker not having sprites in the plumbing constructor
fix: fixes the plumbing feeder and milker droping iron when collected with the plumbing constructor
fix: fixes the weighing scale sometimes not tracking the weight of its occupant correctly. The "last reading" will now also update in real time as weight changes.
fix: fixes breasts sometimes not producing reagents after spawning
/:cl: