### PR TITLE
makes the transfer vote have a popup reminder

### DIFF
--- a/modular_gs/code/modules/voting/vote.dm
+++ b/modular_gs/code/modules/voting/vote.dm
@@ -1,6 +1,14 @@
 #define CHOICE_TRANSFER "Initiate Crew Transfer"
 #define CHOICE_CONTINUE "Continue Playing"
 
+/datum/vote/reset()
+	reminder_fired = FALSE
+	return ..()
+
+/datum/vote/transfer_vote
+	vote_reminder = TRUE
+	force_open_panel_on_reminder = TRUE
+
 /datum/vote/transfer_vote/tiebreaker(list/winners)
 	return CHOICE_CONTINUE
 


### PR DESCRIPTION
## About The Pull Request

Makes it so the transfer vote is forced open when 45 seconds are left

## Why It's Good For The Game

People don't vote because they forget. This should help.

## Changelog

:cl: Swan
qol: makes it so transfer votes are forced open when a person hasn't voted
/:cl: